### PR TITLE
Corregir error de useSocket en la ruta de mensajes

### DIFF
--- a/containers/frontend/src/routes/auth/messages.lazy.tsx
+++ b/containers/frontend/src/routes/auth/messages.lazy.tsx
@@ -1,6 +1,11 @@
 import { createLazyFileRoute } from '@tanstack/react-router'
 import { MessagingApp } from '@/components/messaging/MessagingApp'
+import { SocketProvider } from '@/context/socket'
 
 export const Route = createLazyFileRoute('/auth/messages')({
-  component: MessagingApp
+  component: () => (
+    <SocketProvider>
+      <MessagingApp />
+    </SocketProvider>
+  )
 })


### PR DESCRIPTION
Envolver MessagingApp con SocketProvider para permitir que los componentes ChatList y ChatWindow accedan al contexto de socket. Esto soluciona el error "useSocket must be used within a SocketProvider".