### PR TITLE
Fix events page not found error

### DIFF
--- a/containers/frontend/src/components/events/EventDetail.tsx
+++ b/containers/frontend/src/components/events/EventDetail.tsx
@@ -21,7 +21,7 @@ import { toast } from 'sonner'
 import { useAuth } from '@/auth'
 
 export function EventDetail() {
-  const { eventId } = useParams({ strict: false })
+  const { id } = useParams({ strict: false })
   const navigate = useNavigate()
   const { user } = useAuth()
   const [event, setEvent] = useState<Event | null>(null)
@@ -33,10 +33,10 @@ export function EventDetail() {
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (eventId) {
+    if (id) {
       loadEventData()
     }
-  }, [eventId])
+  }, [id])
 
   useEffect(() => {
     scrollToBottom()
@@ -49,12 +49,12 @@ export function EventDetail() {
   const loadEventData = async () => {
     try {
       setLoading(true)
-      const eventData = await getEvent(Number(eventId))
+      const eventData = await getEvent(Number(id))
       setEvent(eventData)
 
       // Cargar mensajes si el usuario confirmó asistencia
       if (eventData.user_rsvp?.status === 'confirmed') {
-        const messagesData = await getEventMessages(Number(eventId))
+        const messagesData = await getEventMessages(Number(id))
         setMessages(messagesData.messages)
       }
     } catch (error: any) {
@@ -68,7 +68,7 @@ export function EventDetail() {
   const handleRSVP = async (status: 'confirmed' | 'declined') => {
     try {
       setProcessingRSVP(true)
-      await createRSVP(Number(eventId), { status })
+      await createRSVP(Number(id), { status })
       toast.success(status === 'confirmed' ? '¡Asistencia confirmada!' : 'Asistencia declinada')
       await loadEventData()
     } catch (error: any) {
@@ -82,7 +82,7 @@ export function EventDetail() {
   const handleCancelRSVP = async () => {
     try {
       setProcessingRSVP(true)
-      await cancelRSVP(Number(eventId))
+      await cancelRSVP(Number(id))
       toast.success('Asistencia cancelada')
       await loadEventData()
     } catch (error: any) {
@@ -99,7 +99,7 @@ export function EventDetail() {
 
     try {
       setSendingMessage(true)
-      const response = await sendEventMessage(Number(eventId), newMessage)
+      const response = await sendEventMessage(Number(id), newMessage)
       setMessages([...messages, response.event_message])
       setNewMessage('')
     } catch (error: any) {
@@ -114,7 +114,7 @@ export function EventDetail() {
     if (!confirm('¿Estás seguro de que deseas eliminar este evento?')) return
 
     try {
-      await deleteEvent(Number(eventId))
+      await deleteEvent(Number(id))
       toast.success('Evento eliminado correctamente')
       navigate({ to: '/events' })
     } catch (error: any) {
@@ -190,7 +190,7 @@ export function EventDetail() {
                 </div>
                 {isCreator && (
                   <div className="flex gap-2">
-                    <Link to="/events/$eventId/edit" params={{ eventId: eventId! }}>
+                    <Link to="/events/$id/edit" params={{ id: id! }}>
                       <Button variant="outline" size="sm">
                         <Edit className="h-4 w-4 mr-1" />
                         Editar


### PR DESCRIPTION
El componente EventDetail estaba intentando acceder al parámetro 'eventId' cuando la ruta define el parámetro como 'id' ($id). Esto causaba que la página mostrara "Evento no encontrado" al acceder a /events/:id.

Cambios:
- Cambiar todas las referencias de 'eventId' a 'id' en EventDetail.tsx
- Actualizar useParams, loadEventData, handleRSVP, handleCancelRSVP, handleSendMessage, handleDeleteEvent y el Link de edición