### PR TITLE
Add messaging feature to user profiles

### DIFF
--- a/containers/backend/application/app/messaging/routes.py
+++ b/containers/backend/application/app/messaging/routes.py
@@ -101,9 +101,19 @@ def get_or_create_conversation(user_id):
             db.session.add(conversation)
             db.session.commit()
 
+        # Incluir información del otro usuario en la respuesta
+        other_username = other_user.email.split('@')[0] if other_user.email else None
+
         return jsonify({
             'conversation_id': conversation.id,
-            'created': conversation.createdAt.isoformat() if conversation.createdAt else None
+            'created': conversation.createdAt.isoformat() if conversation.createdAt else None,
+            'other_user': {
+                'id': other_user.id,
+                'username': other_username,
+                'first_name': other_user.first_name,
+                'last_name': other_user.last_name,
+                'profile_image': other_user.profile_image
+            }
         }), 200
     except Exception as e:
         db.session.rollback()

--- a/containers/backend/application/app/user/routes.py
+++ b/containers/backend/application/app/user/routes.py
@@ -159,6 +159,7 @@ def get_public_profile(username):
         if not user.is_profile_public:
             # Si el perfil es privado, solo mostrar información muy básica
             return jsonify({
+                'id': user.id,
                 'username': username,
                 'first_name': user.first_name,
                 'last_name': user.last_name,
@@ -186,6 +187,7 @@ def get_public_profile(username):
 
         # Solo devolver información pública
         return jsonify({
+            'id': user.id,
             'username': username,
             'first_name': user.first_name,
             'last_name': user.last_name,

--- a/containers/frontend/src/components/messaging/MessagingApp.tsx
+++ b/containers/frontend/src/components/messaging/MessagingApp.tsx
@@ -1,12 +1,31 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Card } from '@/components/ui/card'
 import { ChatList } from './ChatList'
 import { ChatWindow } from './ChatWindow'
-import { Conversation } from '@/services/messaging/messagingApi'
+import { Conversation, getConversations } from '@/services/messaging/messagingApi'
 import { MessageSquare } from 'lucide-react'
 
-export function MessagingApp() {
+interface MessagingAppProps {
+  initialConversationId?: number
+}
+
+export function MessagingApp({ initialConversationId }: MessagingAppProps) {
   const [selectedConversation, setSelectedConversation] = useState<Conversation | null>(null)
+
+  // Efecto para seleccionar la conversación inicial si se proporciona
+  useEffect(() => {
+    if (initialConversationId) {
+      // Cargar las conversaciones y seleccionar la indicada
+      getConversations().then(conversations => {
+        const conversation = conversations.find(c => c.id === initialConversationId)
+        if (conversation) {
+          setSelectedConversation(conversation)
+        }
+      }).catch(error => {
+        console.error('Error loading conversations:', error)
+      })
+    }
+  }, [initialConversationId])
 
   return (
     <div className="container mx-auto p-4 max-w-7xl">

--- a/containers/frontend/src/routes/auth/messages.lazy.tsx
+++ b/containers/frontend/src/routes/auth/messages.lazy.tsx
@@ -1,11 +1,23 @@
 import { createLazyFileRoute } from '@tanstack/react-router'
 import { MessagingApp } from '@/components/messaging/MessagingApp'
 import { SocketProvider } from '@/context/socket'
+import { z } from 'zod'
+
+const messagesSearchSchema = z.object({
+  conversation_id: z.number().optional()
+})
 
 export const Route = createLazyFileRoute('/auth/messages')({
-  component: () => (
+  validateSearch: messagesSearchSchema,
+  component: MessagesPage
+})
+
+function MessagesPage() {
+  const { conversation_id } = Route.useSearch()
+
+  return (
     <SocketProvider>
-      <MessagingApp />
+      <MessagingApp initialConversationId={conversation_id} />
     </SocketProvider>
   )
-})
+}

--- a/containers/frontend/src/routes/auth/user/$username.lazy.tsx
+++ b/containers/frontend/src/routes/auth/user/$username.lazy.tsx
@@ -83,8 +83,11 @@ function PublicProfile() {
 
       toast.success('Redirigiendo a mensajes...')
 
-      // Navegar a la página de mensajes
-      navigate({ to: '/auth/messages' })
+      // Navegar a la página de mensajes con el ID de la conversación
+      navigate({
+        to: '/auth/messages',
+        search: { conversation_id: result.conversation_id }
+      })
     } catch (error) {
       console.error('Error al crear conversación:', error)
       toast.error('No se pudo iniciar la conversación')

--- a/containers/frontend/src/services/messaging/messagingApi.tsx
+++ b/containers/frontend/src/services/messaging/messagingApi.tsx
@@ -43,7 +43,17 @@ export const getConversations = async (): Promise<Conversation[]> => {
 }
 
 // Obtener o crear conversación con un usuario
-export const getOrCreateConversation = async (userId: number): Promise<{ conversation_id: number; created: string }> => {
+export const getOrCreateConversation = async (userId: number): Promise<{
+  conversation_id: number
+  created: string
+  other_user: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+    profile_image: string
+  }
+}> => {
   const response = await axios.get(`${API_URL}/api/v1/conversations/${userId}`, {
     withCredentials: true,
   })


### PR DESCRIPTION
- Agregar campo 'id' en la respuesta del API de perfil público y privado
- Mejorar respuesta de getOrCreateConversation para incluir datos del otro usuario
- Actualizar interface TypeScript para reflejar los cambios en el API
- Implementar navegación automática a conversación específica al enviar mensaje desde perfil
- Agregar support para conversation_id como parámetro de búsqueda en la ruta de mensajes
- Seleccionar automáticamente la conversación cuando el usuario viene desde un perfil

Esto corrige el problema crítico donde no se podía enviar mensaje desde el perfil porque faltaba el campo 'id' del usuario.