### PR TITLE
Issue #3: Security hardening — schemas, rate limits, CORS, headers

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -60,7 +60,7 @@ Arreglados `is_deleted` vs `deletedAt`, `display_username` property, `ondelete` 
 
 **Estado:** `done`
 **Severidad:** Alta
-**Completado en:** `<SHA>` — 2026-04-17
+**Completado en:** `85b00d9` — 2026-04-17
 
 Añadido módulo `app/schemas/` con Pydantic v2 y decorador `@validate_body` en todos los POST/PUT críticos (events, projects, reviews, messaging, profile). Activado `flask-limiter` (login 5/min, register/recover 3/h, búsqueda 60/min, default 200/min). CORS ahora se lee de `ALLOWED_ORIGINS` env var, rechazando `*`. Headers de seguridad (CSP, HSTS, X-Frame-Options, Permissions-Policy, Referrer-Policy, COOP/CORP) aplicados en `Caddyfile`. Auditado ownership en `update_member_role`/`remove_member` (faltaba verificar `project` antes de dereferenciar).
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -58,25 +58,11 @@ Arreglados `is_deleted` vs `deletedAt`, `display_username` property, `ondelete` 
 
 ## Issue #3 — Hardening de seguridad y validación de entrada
 
-**Estado:** `pending`
+**Estado:** `done`
 **Severidad:** Alta
+**Completado en:** `<SHA>` — 2026-04-17
 
-### Tareas
-
-- [ ] Crear módulo `app/schemas/` con Pydantic v2 y esquemas para: create/update event, create/update project, create review, send message, update profile, RSVP, project member role.
-- [ ] Envolver todos los endpoints POST/PUT con un decorador `@validate_body(Schema)` que inyecte el objeto validado.
-- [ ] Activar `flask-limiter` (ya está en `requirements.txt`):
-    - `/auth/login` → 5/minute por IP
-    - `/auth/register` → 3/hour por IP
-    - Endpoints públicos de búsqueda → 60/minute por IP
-    - Endpoints autenticados generales → 200/minute por user
-- [ ] Configurar CORS explícito en `app/__init__.py`: orígenes desde env var `ALLOWED_ORIGINS` separados por coma. Rechazar `*` en producción.
-- [ ] Headers de seguridad en Caddy (`caddy/Caddyfile` o similar): CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy.
-- [ ] Revisar que TODAS las rutas con `@login_required` verifican ownership cuando modifican recursos (algunos casos en `projects/routes.py` y `events/routes.py` no lo hacen bien).
-
-### Criterio de aceptación
-- Payloads malformados devuelven 400 con detalle claro, no 500.
-- `curl` repetido al login es bloqueado tras 5 intentos.
+Añadido módulo `app/schemas/` con Pydantic v2 y decorador `@validate_body` en todos los POST/PUT críticos (events, projects, reviews, messaging, profile). Activado `flask-limiter` (login 5/min, register/recover 3/h, búsqueda 60/min, default 200/min). CORS ahora se lee de `ALLOWED_ORIGINS` env var, rechazando `*`. Headers de seguridad (CSP, HSTS, X-Frame-Options, Permissions-Policy, Referrer-Policy, COOP/CORP) aplicados en `Caddyfile`. Auditado ownership en `update_member_role`/`remove_member` (faltaba verificar `project` antes de dereferenciar).
 
 ---
 

--- a/containers/backend/application/app/__init__.py
+++ b/containers/backend/application/app/__init__.py
@@ -12,15 +12,12 @@ from flask_socketio import SocketIO
 from app.celery_utils import init_celery
 from redis import Redis
 from app.cache import cache
+from app.rate_limit import limiter
 from app.logger_config import logger
 
-# Extensiones
-db = SQLAlchemy()
-migrate = Migrate()
-login = LoginManager()
-login.login_message = "Por favor, inicia sesión para acceder a esta página."
-mail = Mail()
-socketio = SocketIO(cors_allowed_origins=[
+# Orígenes CORS por defecto si ALLOWED_ORIGINS no está configurado.
+# En producción conviene sobreescribir vía variable de entorno.
+DEFAULT_ALLOWED_ORIGINS = [
     "https://localtalent.es",
     "https://api.localtalent.es",
     # Development origins
@@ -28,7 +25,23 @@ socketio = SocketIO(cors_allowed_origins=[
     "http://localhost:3000",
     "http://127.0.0.1:5173",
     "http://127.0.0.1:3000",
-])
+]
+
+
+def _parse_origins(value: str | None) -> list[str]:
+    if not value:
+        return list(DEFAULT_ALLOWED_ORIGINS)
+    raw = [x.strip() for x in value.split(',')]
+    return [x for x in raw if x and x != '*']
+
+
+# Extensiones
+db = SQLAlchemy()
+migrate = Migrate()
+login = LoginManager()
+login.login_message = "Por favor, inicia sesión para acceder a esta página."
+mail = Mail()
+socketio = SocketIO(cors_allowed_origins=_parse_origins(os.environ.get('ALLOWED_ORIGINS')))
 
 # Declaramos la variable celery a nivel de módulo
 celery = None
@@ -60,22 +73,29 @@ def create_app(config_class=Config):
         'CACHE_KEY_PREFIX': 'lt:',
     })
 
-    # Configurar CORS
-    # Cambio mínimo: actualizar dominios permitidos para reflejar el despliegue actual
-    # Si necesitas añadir más, puedes convertirlo en variable de entorno y dividir por comas.
+    # Configurar CORS explícito desde env var ALLOWED_ORIGINS (separado por comas).
+    # Rechazamos cualquier '*' — orígenes concretos únicamente. En prod conviene
+    # definir ALLOWED_ORIGINS para no depender de los defaults.
+    allowed_origins = _parse_origins(os.environ.get('ALLOWED_ORIGINS'))
+    if not allowed_origins:
+        logger.getChild('cors').warning(
+            "ALLOWED_ORIGINS vacío tras filtrar — el backend rechazará todo CORS"
+        )
     CORS(
         app,
         supports_credentials=True,
-        resources={r"/*": {"origins": [
-            "https://localtalent.es",
-            "https://api.localtalent.es",
-            # Dev origins for local front-end (Vite default port 5173 or alternate 3000)
-            "http://localhost:5173",
-            "http://localhost:3000",
-            "http://127.0.0.1:5173",
-            "http://127.0.0.1:3000",
-        ]}}
+        resources={r"/*": {"origins": allowed_origins}},
     )
+
+    # Rate limiter: si hay Redis disponible, usarlo como storage para que los
+    # límites sean consistentes entre procesos/gunicorn workers.
+    if app.config.get('REDIS_URL'):
+        app.config.setdefault('RATELIMIT_STORAGE_URI', app.config['REDIS_URL'])
+        app.config.setdefault('RATELIMIT_STRATEGY', 'fixed-window')
+    # En tests el limiter puede interferir; permitir desactivarlo desde config.
+    if app.config.get('TESTING'):
+        app.config.setdefault('RATELIMIT_ENABLED', False)
+    limiter.init_app(app)
 
     # Registrar blueprints
     from app.auth import bp as auth_bp

--- a/containers/backend/application/app/auth/routes.py
+++ b/containers/backend/application/app/auth/routes.py
@@ -1,9 +1,11 @@
 from app.auth import bp
 from flask import jsonify, request, current_app
 from flask_login import login_user, logout_user, login_required, current_user
-from app.models import User, JWTToken 
+from app.models import User, JWTToken
 from app import db
 from app.auth.email import send_password_reset_email, send_create_account_email
+from app.rate_limit import limiter
+from flask_limiter.util import get_remote_address
 import random, string
 import pyotp
 from datetime import datetime, timezone
@@ -12,6 +14,7 @@ from app.logger_config import logger
 
 
 @bp.route('/api/v1/check-credentials', methods=['POST'])
+@limiter.limit("5/minute", key_func=get_remote_address)
 def check_credentials():
     """
     Verifica únicamente si el email y contraseña son correctos.
@@ -52,6 +55,7 @@ def check_credentials():
 
 
 @bp.route('/api/v1/verify-otp', methods=['POST'])
+@limiter.limit("5/minute", key_func=get_remote_address)
 def verify_otp():
     """
     Verifica el código OTP y la contraseña antes de iniciar sesión.
@@ -286,6 +290,7 @@ def reset_password(token):
 
 
 @bp.route('/api/v1/recover-password', methods=['POST'])
+@limiter.limit("3/hour", key_func=get_remote_address)
 def recover_password():
     """
     - Recibe una solicitud para recuperar contraseña con el email del usuario.
@@ -323,6 +328,7 @@ def recover_password():
 
 
 @bp.route('/api/v1/register', methods=['POST'])
+@limiter.limit("3/hour", key_func=get_remote_address)
 def register():
     """Permite solicitar un enlace de registro sin necesitar un token previo."""
     try:

--- a/containers/backend/application/app/events/routes.py
+++ b/containers/backend/application/app/events/routes.py
@@ -9,6 +9,15 @@ from app.cache import (
     invalidate_event_confirmed_count,
 )
 from app.models import Event, EventRSVP, EventInvitation, EventMessage, User, Notification
+from app.schemas import (
+    EventCreateSchema,
+    EventUpdateSchema,
+    RSVPSchema,
+    EventInvitationSchema,
+    EventInvitationResponseSchema,
+    MessageSendSchema,
+    validate_body,
+)
 from datetime import datetime, timezone
 from sqlalchemy import func, and_, or_
 from sqlalchemy.orm import selectinload
@@ -355,49 +364,29 @@ def get_event(event_id):
 
 @bp.route('/api/v1/events', methods=['POST'])
 @login_required
-def create_event():
+@validate_body(EventCreateSchema)
+def create_event(payload: EventCreateSchema):
     """Crear un nuevo evento"""
     try:
-        data = request.get_json()
-
-        # Validar campos requeridos
-        required_fields = ['title', 'start_date', 'event_type']
-        for field in required_fields:
-            if not data or field not in data:
-                return jsonify({'error': f'Campo requerido: {field}'}), 400
-
-        # Validar fecha
-        try:
-            start_date = datetime.fromisoformat(data['start_date'].replace('Z', '+00:00'))
-        except (ValueError, TypeError):
-            return jsonify({'error': 'Formato de fecha inválido (usar ISO 8601)'}), 400
-
-        end_date = None
-        if 'end_date' in data and data['end_date']:
-            try:
-                end_date = datetime.fromisoformat(data['end_date'].replace('Z', '+00:00'))
-            except (ValueError, TypeError):
-                return jsonify({'error': 'Formato de fecha de fin inválido'}), 400
-
         # Crear evento
         event = Event(
-            title=data['title'],
-            description=data.get('description'),
-            event_type=data['event_type'],
+            title=payload.title,
+            description=payload.description,
+            event_type=payload.event_type,
             creator_id=current_user.id,
-            start_date=start_date,
-            end_date=end_date,
-            is_online=data.get('is_online', False),
-            meeting_url=data.get('meeting_url'),
-            address=data.get('address'),
-            city=data.get('city'),
-            country=data.get('country'),
-            latitude=data.get('latitude'),
-            longitude=data.get('longitude'),
-            max_attendees=data.get('max_attendees'),
-            is_public=data.get('is_public', True),
-            category=data.get('category'),
-            image_url=data.get('image_url')
+            start_date=payload.start_date,
+            end_date=payload.end_date,
+            is_online=payload.is_online,
+            meeting_url=payload.meeting_url,
+            address=payload.address,
+            city=payload.city,
+            country=payload.country,
+            latitude=payload.latitude,
+            longitude=payload.longitude,
+            max_attendees=payload.max_attendees,
+            is_public=payload.is_public,
+            category=payload.category,
+            image_url=payload.image_url,
         )
 
         db.session.add(event)
@@ -431,7 +420,8 @@ def create_event():
 
 @bp.route('/api/v1/events/<int:event_id>', methods=['PUT'])
 @login_required
-def update_event(event_id):
+@validate_body(EventUpdateSchema)
+def update_event(event_id, payload: EventUpdateSchema):
     """Actualizar un evento (solo el creador)"""
     try:
         event = Event.query.filter_by(
@@ -443,65 +433,10 @@ def update_event(event_id):
         if not event:
             return jsonify({'error': 'Evento no encontrado'}), 404
 
-        data = request.get_json()
-
-        # Actualizar campos
-        if 'title' in data:
-            event.title = data['title']
-
-        if 'description' in data:
-            event.description = data['description']
-
-        if 'event_type' in data:
-            event.event_type = data['event_type']
-
-        if 'start_date' in data:
-            try:
-                event.start_date = datetime.fromisoformat(data['start_date'].replace('Z', '+00:00'))
-            except (ValueError, TypeError):
-                return jsonify({'error': 'Formato de fecha inválido'}), 400
-
-        if 'end_date' in data:
-            if data['end_date']:
-                try:
-                    event.end_date = datetime.fromisoformat(data['end_date'].replace('Z', '+00:00'))
-                except (ValueError, TypeError):
-                    return jsonify({'error': 'Formato de fecha de fin inválido'}), 400
-            else:
-                event.end_date = None
-
-        if 'is_online' in data:
-            event.is_online = data['is_online']
-
-        if 'meeting_url' in data:
-            event.meeting_url = data['meeting_url']
-
-        if 'address' in data:
-            event.address = data['address']
-
-        if 'city' in data:
-            event.city = data['city']
-
-        if 'country' in data:
-            event.country = data['country']
-
-        if 'latitude' in data:
-            event.latitude = data['latitude']
-
-        if 'longitude' in data:
-            event.longitude = data['longitude']
-
-        if 'max_attendees' in data:
-            event.max_attendees = data['max_attendees']
-
-        if 'is_public' in data:
-            event.is_public = data['is_public']
-
-        if 'category' in data:
-            event.category = data['category']
-
-        if 'image_url' in data:
-            event.image_url = data['image_url']
+        # Aplicar solo los campos provistos (model_fields_set respeta la semántica PATCH-like)
+        data = payload.model_dump(exclude_unset=True)
+        for field, value in data.items():
+            setattr(event, field, value)
 
         db.session.commit()
 
@@ -549,7 +484,8 @@ def delete_event(event_id):
 
 @bp.route('/api/v1/events/<int:event_id>/rsvp', methods=['POST'])
 @login_required
-def create_rsvp(event_id):
+@validate_body(RSVPSchema)
+def create_rsvp(event_id, payload: RSVPSchema):
     """Confirmar/declinar asistencia a un evento"""
     try:
         event = Event.query.filter_by(
@@ -571,11 +507,7 @@ def create_rsvp(event_id):
             if not invitation and current_user.id != event.creator_id:
                 return jsonify({'error': 'Este es un evento privado'}), 403
 
-        data = request.get_json()
-        status = data.get('status', 'confirmed')
-
-        if status not in ['confirmed', 'declined', 'pending']:
-            return jsonify({'error': 'Estado inválido'}), 400
+        status = payload.status
 
         # Verificar si hay cupo disponible
         if status == 'confirmed' and event.max_attendees:
@@ -599,7 +531,7 @@ def create_rsvp(event_id):
             # Actualizar RSVP existente
             existing_rsvp.status = status
             existing_rsvp.response_date = datetime.now(timezone.utc)
-            existing_rsvp.notes = data.get('notes')
+            existing_rsvp.notes = payload.notes
         else:
             # Crear nuevo RSVP
             rsvp = EventRSVP(
@@ -607,7 +539,7 @@ def create_rsvp(event_id):
                 user_id=current_user.id,
                 status=status,
                 response_date=datetime.now(timezone.utc),
-                notes=data.get('notes')
+                notes=payload.notes,
             )
             db.session.add(rsvp)
 
@@ -671,7 +603,8 @@ def cancel_rsvp(event_id):
 
 @bp.route('/api/v1/events/<int:event_id>/invitations', methods=['POST'])
 @login_required
-def send_invitation(event_id):
+@validate_body(EventInvitationSchema)
+def send_invitation(event_id, payload: EventInvitationSchema):
     """Enviar invitación a un evento"""
     try:
         event = Event.query.filter_by(
@@ -683,12 +616,7 @@ def send_invitation(event_id):
         if not event:
             return jsonify({'error': 'Evento no encontrado o no tienes permisos'}), 404
 
-        data = request.get_json()
-
-        if not data or 'invitee_id' not in data:
-            return jsonify({'error': 'Campo requerido: invitee_id'}), 400
-
-        invitee_id = data['invitee_id']
+        invitee_id = payload.invitee_id
 
         # Verificar que el invitado existe
         invitee = User.query.filter_by(
@@ -719,7 +647,7 @@ def send_invitation(event_id):
             event_id=event_id,
             inviter_id=current_user.id,
             invitee_id=invitee_id,
-            message=data.get('message'),
+            message=payload.message,
             status='pending'
         )
 
@@ -755,7 +683,8 @@ def send_invitation(event_id):
 
 @bp.route('/api/v1/events/invitations/<int:invitation_id>/respond', methods=['PUT'])
 @login_required
-def respond_invitation(invitation_id):
+@validate_body(EventInvitationResponseSchema)
+def respond_invitation(invitation_id, payload: EventInvitationResponseSchema):
     """Responder a una invitación de evento"""
     try:
         invitation = EventInvitation.query.filter_by(
@@ -767,12 +696,7 @@ def respond_invitation(invitation_id):
         if not invitation:
             return jsonify({'error': 'Invitación no encontrada'}), 404
 
-        data = request.get_json()
-        status = data.get('status')
-
-        if status not in ['accepted', 'declined']:
-            return jsonify({'error': 'Estado inválido (accepted o declined)'}), 400
-
+        status = payload.status
         invitation.status = status
 
         # Si acepta, crear RSVP automáticamente en la misma transacción
@@ -925,7 +849,8 @@ def get_event_messages(event_id):
 
 @bp.route('/api/v1/events/<int:event_id>/messages', methods=['POST'])
 @login_required
-def send_event_message(event_id):
+@validate_body(MessageSendSchema)
+def send_event_message(event_id, payload: MessageSendSchema):
     """Enviar mensaje al chat grupal del evento"""
     try:
         # Verificar que el usuario es asistente confirmado o creador
@@ -947,16 +872,11 @@ def send_event_message(event_id):
         if not rsvp and current_user.id != event.creator_id:
             return jsonify({'error': 'Debes confirmar asistencia para enviar mensajes'}), 403
 
-        data = request.get_json()
-
-        if not data or 'content' not in data:
-            return jsonify({'error': 'Campo requerido: content'}), 400
-
         # Crear mensaje
         message = EventMessage(
             event_id=event_id,
             sender_id=current_user.id,
-            content=data['content']
+            content=payload.content,
         )
 
         db.session.add(message)

--- a/containers/backend/application/app/messaging/routes.py
+++ b/containers/backend/application/app/messaging/routes.py
@@ -4,6 +4,7 @@ from app.messaging import bp
 from app.logger_config import logger
 from app import db
 from app.models import User, Conversation, Message
+from app.schemas import MessageSendSchema, validate_body
 from datetime import datetime, timezone
 from sqlalchemy import or_, and_, func, case
 from sqlalchemy.orm import selectinload
@@ -222,7 +223,8 @@ def get_messages(conversation_id):
 
 @bp.route('/api/v1/conversations/<int:conversation_id>/messages', methods=['POST'])
 @login_required
-def send_message(conversation_id):
+@validate_body(MessageSendSchema)
+def send_message(conversation_id, payload: MessageSendSchema):
     """Enviar mensaje a una conversación (REST endpoint)"""
     try:
         # Verificar que el usuario es participante de la conversación
@@ -239,9 +241,7 @@ def send_message(conversation_id):
         if not conversation:
             return jsonify({'error': 'Conversación no encontrada'}), 404
 
-        data = request.get_json()
-        content = data.get('content', '').strip()
-
+        content = payload.content.strip()
         if not content:
             return jsonify({'error': 'El mensaje no puede estar vacío'}), 400
 

--- a/containers/backend/application/app/projects/routes.py
+++ b/containers/backend/application/app/projects/routes.py
@@ -4,6 +4,14 @@ from app.projects import bp
 from app.logger_config import logger
 from app import db
 from app.models import Project, ProjectMember, User, Notification
+from app.schemas import (
+    ProjectCreateSchema,
+    ProjectUpdateSchema,
+    ProjectMemberSchema,
+    ProjectMemberRoleSchema,
+    ProjectMemberResponseSchema,
+    validate_body,
+)
 from datetime import datetime, timezone
 from sqlalchemy import func
 from sqlalchemy.orm import selectinload
@@ -202,40 +210,24 @@ def get_project(project_id):
 
 @bp.route('/api/v1/projects', methods=['POST'])
 @login_required
-def create_project():
+@validate_body(ProjectCreateSchema)
+def create_project(payload: ProjectCreateSchema):
     """Crear un nuevo proyecto"""
     try:
-        data = request.get_json()
-
-        # Validar campos requeridos
-        if not data or 'title' not in data:
-            return jsonify({'error': 'Campo requerido: title'}), 400
-
         # Crear proyecto
         project = Project(
-            title=data['title'],
-            description=data.get('description'),
+            title=payload.title,
+            description=payload.description,
             creator_id=current_user.id,
-            status=data.get('status', 'draft'),
-            required_skills=data.get('required_skills', []),
-            max_members=data.get('max_members'),
-            is_public=data.get('is_public', True),
-            category=data.get('category'),
-            image_url=data.get('image_url')
+            status=payload.status,
+            required_skills=payload.required_skills,
+            max_members=payload.max_members,
+            is_public=payload.is_public,
+            category=payload.category,
+            image_url=payload.image_url,
+            start_date=payload.start_date,
+            end_date=payload.end_date,
         )
-
-        # Fechas opcionales
-        if 'start_date' in data and data['start_date']:
-            try:
-                project.start_date = datetime.fromisoformat(data['start_date'].replace('Z', '+00:00'))
-            except (ValueError, TypeError):
-                return jsonify({'error': 'Formato de fecha de inicio inválido'}), 400
-
-        if 'end_date' in data and data['end_date']:
-            try:
-                project.end_date = datetime.fromisoformat(data['end_date'].replace('Z', '+00:00'))
-            except (ValueError, TypeError):
-                return jsonify({'error': 'Formato de fecha de fin inválido'}), 400
 
         db.session.add(project)
         db.session.flush()  # Obtener project.id sin cerrar la transacción
@@ -268,7 +260,8 @@ def create_project():
 
 @bp.route('/api/v1/projects/<int:project_id>', methods=['PUT'])
 @login_required
-def update_project(project_id):
+@validate_body(ProjectUpdateSchema)
+def update_project(project_id, payload: ProjectUpdateSchema):
     """Actualizar un proyecto (solo el creador o owners)"""
     try:
         project = Project.query.filter_by(
@@ -290,52 +283,9 @@ def update_project(project_id):
         if current_user.id != project.creator_id and not member:
             return jsonify({'error': 'No tienes permisos para editar este proyecto'}), 403
 
-        data = request.get_json()
-
-        # Actualizar campos
-        if 'title' in data:
-            project.title = data['title']
-
-        if 'description' in data:
-            project.description = data['description']
-
-        if 'status' in data:
-            if data['status'] not in ['draft', 'active', 'completed', 'cancelled']:
-                return jsonify({'error': 'Estado inválido'}), 400
-            project.status = data['status']
-
-        if 'start_date' in data:
-            if data['start_date']:
-                try:
-                    project.start_date = datetime.fromisoformat(data['start_date'].replace('Z', '+00:00'))
-                except (ValueError, TypeError):
-                    return jsonify({'error': 'Formato de fecha de inicio inválido'}), 400
-            else:
-                project.start_date = None
-
-        if 'end_date' in data:
-            if data['end_date']:
-                try:
-                    project.end_date = datetime.fromisoformat(data['end_date'].replace('Z', '+00:00'))
-                except (ValueError, TypeError):
-                    return jsonify({'error': 'Formato de fecha de fin inválido'}), 400
-            else:
-                project.end_date = None
-
-        if 'required_skills' in data:
-            project.required_skills = data['required_skills']
-
-        if 'max_members' in data:
-            project.max_members = data['max_members']
-
-        if 'is_public' in data:
-            project.is_public = data['is_public']
-
-        if 'category' in data:
-            project.category = data['category']
-
-        if 'image_url' in data:
-            project.image_url = data['image_url']
+        data = payload.model_dump(exclude_unset=True)
+        for field, value in data.items():
+            setattr(project, field, value)
 
         db.session.commit()
 
@@ -384,7 +334,8 @@ def delete_project(project_id):
 
 @bp.route('/api/v1/projects/<int:project_id>/members', methods=['POST'])
 @login_required
-def add_member(project_id):
+@validate_body(ProjectMemberSchema)
+def add_member(project_id, payload: ProjectMemberSchema):
     """Agregar un miembro al proyecto o solicitar unirse"""
     try:
         project = Project.query.filter_by(
@@ -395,10 +346,8 @@ def add_member(project_id):
         if not project:
             return jsonify({'error': 'Proyecto no encontrado'}), 404
 
-        data = request.get_json()
-
         # Si se especifica user_id, es una invitación (solo owners)
-        if 'user_id' in data:
+        if payload.user_id is not None:
             # Verificar permisos
             member = ProjectMember.query.filter_by(
                 project_id=project_id,
@@ -410,7 +359,7 @@ def add_member(project_id):
             if current_user.id != project.creator_id and not member:
                 return jsonify({'error': 'Solo los owners pueden invitar miembros'}), 403
 
-            user_id = data['user_id']
+            user_id = payload.user_id
 
             # Verificar que el usuario existe
             user = User.query.filter_by(
@@ -436,7 +385,7 @@ def add_member(project_id):
             new_member = ProjectMember(
                 project_id=project_id,
                 user_id=user_id,
-                role=data.get('role', 'contributor'),
+                role=payload.role or 'contributor',
                 status='pending'
             )
 
@@ -531,7 +480,8 @@ def add_member(project_id):
 
 @bp.route('/api/v1/projects/members/<int:member_id>/respond', methods=['PUT'])
 @login_required
-def respond_membership(member_id):
+@validate_body(ProjectMemberResponseSchema)
+def respond_membership(member_id, payload: ProjectMemberResponseSchema):
     """Responder a una invitación de proyecto"""
     try:
         member = ProjectMember.query.filter_by(
@@ -544,11 +494,7 @@ def respond_membership(member_id):
         if not member:
             return jsonify({'error': 'Invitación no encontrada'}), 404
 
-        data = request.get_json()
-        action = data.get('action')  # 'accept' o 'decline'
-
-        if action not in ['accept', 'decline']:
-            return jsonify({'error': 'Acción inválida (accept o decline)'}), 400
+        action = payload.action  # 'accept' o 'decline'
 
         if action == 'accept':
             member.status = 'active'
@@ -583,9 +529,18 @@ def respond_membership(member_id):
 
 @bp.route('/api/v1/projects/<int:project_id>/members/<int:user_id>', methods=['PUT'])
 @login_required
-def update_member_role(project_id, user_id):
+@validate_body(ProjectMemberRoleSchema)
+def update_member_role(project_id, user_id, payload: ProjectMemberRoleSchema):
     """Actualizar rol de un miembro (solo owners)"""
     try:
+        project = Project.query.filter_by(
+            id=project_id,
+            deletedAt=None,
+        ).first()
+
+        if not project:
+            return jsonify({'error': 'Proyecto no encontrado'}), 404
+
         # Verificar permisos
         owner_member = ProjectMember.query.filter_by(
             project_id=project_id,
@@ -593,8 +548,6 @@ def update_member_role(project_id, user_id):
             role='owner',
             deletedAt=None
         ).first()
-
-        project = Project.query.get(project_id)
 
         if current_user.id != project.creator_id and not owner_member:
             return jsonify({'error': 'Solo los owners pueden cambiar roles'}), 403
@@ -609,12 +562,7 @@ def update_member_role(project_id, user_id):
         if not member:
             return jsonify({'error': 'Miembro no encontrado'}), 404
 
-        data = request.get_json()
-        new_role = data.get('role')
-
-        if new_role not in ['owner', 'collaborator', 'contributor']:
-            return jsonify({'error': 'Rol inválido'}), 400
-
+        new_role = payload.role
         member.role = new_role
         db.session.commit()
 
@@ -642,14 +590,20 @@ def remove_member(project_id, user_id):
         is_self = user_id == current_user.id
 
         if not is_self:
+            project = Project.query.filter_by(
+                id=project_id,
+                deletedAt=None,
+            ).first()
+
+            if not project:
+                return jsonify({'error': 'Proyecto no encontrado'}), 404
+
             owner_member = ProjectMember.query.filter_by(
                 project_id=project_id,
                 user_id=current_user.id,
                 role='owner',
                 deletedAt=None
             ).first()
-
-            project = Project.query.get(project_id)
 
             if current_user.id != project.creator_id and not owner_member:
                 return jsonify({'error': 'Solo los owners pueden remover miembros'}), 403

--- a/containers/backend/application/app/rate_limit.py
+++ b/containers/backend/application/app/rate_limit.py
@@ -1,0 +1,33 @@
+"""
+Rate limiter (flask-limiter) configurado para LocalTalent.
+
+- Usa Redis como storage si hay `REDIS_URL`; memoria en tests.
+- Clave por defecto: `user.id` si hay sesión, IP en caso contrario.
+- Límite global moderado para endpoints autenticados.
+"""
+from flask_limiter import Limiter
+from flask_login import current_user
+
+
+def _resolve_key():
+    """Identificar al cliente para contar peticiones.
+
+    Usuarios autenticados → `user:<id>` (evita que usuarios compartiendo IP
+    se bloqueen entre ellos). Resto → IP remota (a través de get_remote_address).
+    """
+    try:
+        if current_user.is_authenticated:
+            return f"user:{current_user.id}"
+    except Exception:
+        pass
+    # Fallback a IP
+    from flask_limiter.util import get_remote_address
+    return get_remote_address()
+
+
+# Se creará `limiter` sin app y se enlazará en `create_app`.
+limiter = Limiter(
+    key_func=_resolve_key,
+    default_limits=["200/minute"],
+    headers_enabled=True,
+)

--- a/containers/backend/application/app/reviews/routes.py
+++ b/containers/backend/application/app/reviews/routes.py
@@ -9,6 +9,7 @@ from app.cache import (
     invalidate_user_rating,
 )
 from app.models import Review, User, Conversation
+from app.schemas import ReviewCreateSchema, ReviewUpdateSchema, validate_body
 from datetime import datetime, timezone
 from sqlalchemy import func
 
@@ -83,22 +84,13 @@ def can_review_user(username):
 
 @bp.route('/api/v1/reviews', methods=['POST'])
 @login_required
-def create_review():
+@validate_body(ReviewCreateSchema)
+def create_review(payload: ReviewCreateSchema):
     """Crear una nueva review"""
     try:
-        data = request.get_json()
-
-        # Validar campos requeridos
-        if not data or 'reviewee_id' not in data or 'rating' not in data:
-            return jsonify({'error': 'Faltan campos requeridos (reviewee_id, rating)'}), 400
-
-        reviewee_id = data['reviewee_id']
-        rating = data['rating']
-        comment = data.get('comment', '')
-
-        # Validar rating
-        if not isinstance(rating, int) or rating < 1 or rating > 5:
-            return jsonify({'error': 'El rating debe ser un número entre 1 y 5'}), 400
+        reviewee_id = payload.reviewee_id
+        rating = payload.rating
+        comment = payload.comment or ''
 
         # Buscar reviewee
         reviewee = User.query.filter_by(
@@ -269,7 +261,8 @@ def get_user_average_rating(username):
 
 @bp.route('/api/v1/reviews/<int:review_id>', methods=['PUT'])
 @login_required
-def update_review(review_id):
+@validate_body(ReviewUpdateSchema)
+def update_review(review_id, payload: ReviewUpdateSchema):
     """Actualizar una review (solo el creador)"""
     try:
         review = Review.query.filter_by(
@@ -281,17 +274,9 @@ def update_review(review_id):
         if not review:
             return jsonify({'error': 'Valoración no encontrada'}), 404
 
-        data = request.get_json()
-
-        # Actualizar campos
-        if 'rating' in data:
-            rating = data['rating']
-            if not isinstance(rating, int) or rating < 1 or rating > 5:
-                return jsonify({'error': 'El rating debe ser un número entre 1 y 5'}), 400
-            review.rating = rating
-
-        if 'comment' in data:
-            review.comment = data['comment']
+        data = payload.model_dump(exclude_unset=True)
+        for field, value in data.items():
+            setattr(review, field, value)
 
         db.session.commit()
         invalidate_user_rating(review.reviewee_id)

--- a/containers/backend/application/app/schemas/__init__.py
+++ b/containers/backend/application/app/schemas/__init__.py
@@ -1,0 +1,38 @@
+from app.schemas.common import validate_body, ValidationError
+from app.schemas.events import (
+    EventCreateSchema,
+    EventUpdateSchema,
+    RSVPSchema,
+    EventInvitationSchema,
+    EventInvitationResponseSchema,
+)
+from app.schemas.projects import (
+    ProjectCreateSchema,
+    ProjectUpdateSchema,
+    ProjectMemberSchema,
+    ProjectMemberRoleSchema,
+    ProjectMemberResponseSchema,
+)
+from app.schemas.reviews import ReviewCreateSchema, ReviewUpdateSchema
+from app.schemas.messaging import MessageSendSchema
+from app.schemas.user import ProfileUpdateSchema, UsernameUpdateSchema
+
+__all__ = [
+    'validate_body',
+    'ValidationError',
+    'EventCreateSchema',
+    'EventUpdateSchema',
+    'RSVPSchema',
+    'EventInvitationSchema',
+    'EventInvitationResponseSchema',
+    'ProjectCreateSchema',
+    'ProjectUpdateSchema',
+    'ProjectMemberSchema',
+    'ProjectMemberRoleSchema',
+    'ProjectMemberResponseSchema',
+    'ReviewCreateSchema',
+    'ReviewUpdateSchema',
+    'MessageSendSchema',
+    'ProfileUpdateSchema',
+    'UsernameUpdateSchema',
+]

--- a/containers/backend/application/app/schemas/common.py
+++ b/containers/backend/application/app/schemas/common.py
@@ -1,0 +1,59 @@
+"""
+Helpers de validación de entrada basados en Pydantic v2.
+
+Provee un decorador `@validate_body(Schema)` que:
+- Parsea JSON de la request.
+- Valida contra el esquema pydantic.
+- En caso de error, devuelve 400 con un detalle claro.
+- Si la validación pasa, inyecta la instancia validada como kwarg `payload`.
+"""
+from functools import wraps
+from flask import request, jsonify
+from pydantic import BaseModel, ValidationError as PydanticValidationError
+
+
+class ValidationError(Exception):
+    """Error de validación de esquema con detalle legible."""
+
+    def __init__(self, errors):
+        self.errors = errors
+        super().__init__("Datos inválidos")
+
+
+def _format_errors(exc: PydanticValidationError):
+    """Devuelve una lista compacta [{field, message, type}]."""
+    out = []
+    for err in exc.errors():
+        loc = ".".join(str(x) for x in err.get('loc', ()))
+        out.append({
+            'field': loc or '<root>',
+            'message': err.get('msg'),
+            'type': err.get('type'),
+        })
+    return out
+
+
+def validate_body(schema: type[BaseModel]):
+    """Decorador: valida request.json contra `schema` y lo inyecta como `payload`."""
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            raw = request.get_json(silent=True)
+            if raw is None:
+                return jsonify({
+                    'error': 'Body JSON requerido',
+                    'details': [{'field': '<root>', 'message': 'Se esperaba JSON'}],
+                }), 400
+            try:
+                payload = schema.model_validate(raw)
+            except PydanticValidationError as exc:
+                return jsonify({
+                    'error': 'Datos inválidos',
+                    'details': _format_errors(exc),
+                }), 400
+            return fn(*args, payload=payload, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/containers/backend/application/app/schemas/events.py
+++ b/containers/backend/application/app/schemas/events.py
@@ -1,0 +1,89 @@
+from datetime import datetime
+from typing import Literal, Optional
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+EVENT_TYPES = {'workshop', 'meetup', 'conference', 'collaboration', 'networking', 'other'}
+RSVP_STATUSES = {'confirmed', 'declined', 'pending'}
+
+
+class EventCreateSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    title: str = Field(min_length=1, max_length=200)
+    description: Optional[str] = Field(default=None, max_length=5000)
+    event_type: str
+    start_date: datetime
+    end_date: Optional[datetime] = None
+    is_online: bool = False
+    meeting_url: Optional[str] = Field(default=None, max_length=500)
+    address: Optional[str] = Field(default=None, max_length=300)
+    city: Optional[str] = Field(default=None, max_length=100)
+    country: Optional[str] = Field(default=None, max_length=100)
+    latitude: Optional[float] = Field(default=None, ge=-90, le=90)
+    longitude: Optional[float] = Field(default=None, ge=-180, le=180)
+    max_attendees: Optional[int] = Field(default=None, ge=1, le=100000)
+    is_public: bool = True
+    category: Optional[str] = Field(default=None, max_length=50)
+    image_url: Optional[str] = Field(default=None, max_length=500)
+
+    @field_validator('event_type')
+    @classmethod
+    def check_event_type(cls, v: str) -> str:
+        if v not in EVENT_TYPES:
+            raise ValueError(f"event_type inválido. Debe ser uno de {sorted(EVENT_TYPES)}")
+        return v
+
+    @model_validator(mode='after')
+    def check_dates(self):
+        if self.end_date and self.start_date and self.end_date < self.start_date:
+            raise ValueError("end_date no puede ser anterior a start_date")
+        return self
+
+
+class EventUpdateSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    title: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    description: Optional[str] = Field(default=None, max_length=5000)
+    event_type: Optional[str] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    is_online: Optional[bool] = None
+    meeting_url: Optional[str] = Field(default=None, max_length=500)
+    address: Optional[str] = Field(default=None, max_length=300)
+    city: Optional[str] = Field(default=None, max_length=100)
+    country: Optional[str] = Field(default=None, max_length=100)
+    latitude: Optional[float] = Field(default=None, ge=-90, le=90)
+    longitude: Optional[float] = Field(default=None, ge=-180, le=180)
+    max_attendees: Optional[int] = Field(default=None, ge=1, le=100000)
+    is_public: Optional[bool] = None
+    category: Optional[str] = Field(default=None, max_length=50)
+    image_url: Optional[str] = Field(default=None, max_length=500)
+
+    @field_validator('event_type')
+    @classmethod
+    def check_event_type(cls, v):
+        if v is not None and v not in EVENT_TYPES:
+            raise ValueError(f"event_type inválido. Debe ser uno de {sorted(EVENT_TYPES)}")
+        return v
+
+
+class RSVPSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    status: Literal['confirmed', 'declined', 'pending'] = 'confirmed'
+    notes: Optional[str] = Field(default=None, max_length=1000)
+
+
+class EventInvitationSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    invitee_id: int = Field(ge=1)
+    message: Optional[str] = Field(default=None, max_length=1000)
+
+
+class EventInvitationResponseSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    status: Literal['accepted', 'declined']

--- a/containers/backend/application/app/schemas/messaging.py
+++ b/containers/backend/application/app/schemas/messaging.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MessageSendSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    content: str = Field(min_length=1, max_length=5000)

--- a/containers/backend/application/app/schemas/projects.py
+++ b/containers/backend/application/app/schemas/projects.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from typing import Literal, Optional
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+PROJECT_STATUSES = {'draft', 'active', 'completed', 'cancelled'}
+PROJECT_MEMBER_ROLES = {'owner', 'admin', 'member', 'contributor'}
+
+
+class ProjectCreateSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    title: str = Field(min_length=1, max_length=200)
+    description: Optional[str] = Field(default=None, max_length=10000)
+    status: Literal['draft', 'active', 'completed', 'cancelled'] = 'draft'
+    required_skills: list[str] = Field(default_factory=list)
+    max_members: Optional[int] = Field(default=None, ge=1, le=10000)
+    is_public: bool = True
+    category: Optional[str] = Field(default=None, max_length=50)
+    image_url: Optional[str] = Field(default=None, max_length=500)
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+
+    @model_validator(mode='after')
+    def check_dates(self):
+        if self.end_date and self.start_date and self.end_date < self.start_date:
+            raise ValueError("end_date no puede ser anterior a start_date")
+        return self
+
+
+class ProjectUpdateSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    title: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    description: Optional[str] = Field(default=None, max_length=10000)
+    status: Optional[Literal['draft', 'active', 'completed', 'cancelled']] = None
+    required_skills: Optional[list[str]] = None
+    max_members: Optional[int] = Field(default=None, ge=1, le=10000)
+    is_public: Optional[bool] = None
+    category: Optional[str] = Field(default=None, max_length=50)
+    image_url: Optional[str] = Field(default=None, max_length=500)
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+
+
+class ProjectMemberSchema(BaseModel):
+    """Body para `POST /projects/<id>/members`.
+
+    - Si se pasa `user_id`, el caller (owner) invita a un usuario.
+    - Si no, el propio usuario solicita unirse.
+    """
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    user_id: Optional[int] = Field(default=None, ge=1)
+    role: Optional[str] = Field(default=None, max_length=30)
+    message: Optional[str] = Field(default=None, max_length=1000)
+
+
+class ProjectMemberRoleSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    role: Literal['owner', 'collaborator', 'contributor']
+
+
+class ProjectMemberResponseSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    action: Literal['accept', 'decline']

--- a/containers/backend/application/app/schemas/reviews.py
+++ b/containers/backend/application/app/schemas/reviews.py
@@ -1,0 +1,17 @@
+from typing import Optional
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ReviewCreateSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    reviewee_id: int = Field(ge=1)
+    rating: int = Field(ge=1, le=5)
+    comment: Optional[str] = Field(default='', max_length=2000)
+
+
+class ReviewUpdateSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    rating: Optional[int] = Field(default=None, ge=1, le=5)
+    comment: Optional[str] = Field(default=None, max_length=2000)

--- a/containers/backend/application/app/schemas/user.py
+++ b/containers/backend/application/app/schemas/user.py
@@ -1,0 +1,37 @@
+import re
+from typing import Optional
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+USERNAME_REGEX = re.compile(r'^[a-z0-9_-]{3,30}$')
+
+
+class ProfileUpdateSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    first_name: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    last_name: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    bio: Optional[str] = Field(default=None, max_length=500)
+    skills: Optional[list[str]] = None
+    category: Optional[str] = Field(default=None, max_length=50)
+    address: Optional[str] = Field(default=None, max_length=300)
+    city: Optional[str] = Field(default=None, max_length=100)
+    country: Optional[str] = Field(default=None, max_length=100)
+    latitude: Optional[float] = Field(default=None, ge=-90, le=90)
+    longitude: Optional[float] = Field(default=None, ge=-180, le=180)
+
+
+class UsernameUpdateSchema(BaseModel):
+    model_config = ConfigDict(extra='ignore', str_strip_whitespace=True)
+
+    username: str = Field(min_length=3, max_length=30)
+
+    @field_validator('username')
+    @classmethod
+    def check_format(cls, v: str) -> str:
+        v = v.lower()
+        if not USERNAME_REGEX.match(v):
+            raise ValueError(
+                "username debe tener 3-30 caracteres con sólo minúsculas, dígitos, '_' y '-'"
+            )
+        return v

--- a/containers/backend/application/app/user/routes.py
+++ b/containers/backend/application/app/user/routes.py
@@ -4,6 +4,9 @@ from app.user import bp
 from app.logger_config import logger
 from app import db
 from app.models import User, Portfolio, SavedSearch, Review
+from app.schemas import ProfileUpdateSchema, validate_body
+from app.rate_limit import limiter
+from flask_limiter.util import get_remote_address
 import os
 from werkzeug.utils import secure_filename
 from sqlalchemy import func, or_, and_
@@ -87,37 +90,14 @@ def get_my_profile():
 
 @bp.route('/api/v1/profile/me', methods=['PUT'])
 @login_required
-def update_my_profile():
+@validate_body(ProfileUpdateSchema)
+def update_my_profile(payload: ProfileUpdateSchema):
     """Actualizar el perfil del usuario autenticado"""
     try:
         user = current_user
-        data = request.get_json()
-
-        # Campos que se pueden actualizar
-        if 'first_name' in data:
-            user.first_name = data['first_name']
-        if 'last_name' in data:
-            user.last_name = data['last_name']
-        if 'bio' in data:
-            bio = data['bio']
-            # Validar límite de caracteres en bio
-            if bio and len(bio) > 500:
-                return jsonify({'error': 'La biografía no puede exceder 500 caracteres'}), 400
-            user.bio = bio
-        if 'skills' in data:
-            user.skills = data['skills'] if isinstance(data['skills'], list) else []
-        if 'category' in data:
-            user.category = data['category']
-        if 'address' in data:
-            user.address = data['address']
-        if 'city' in data:
-            user.city = data['city']
-        if 'country' in data:
-            user.country = data['country']
-        if 'latitude' in data:
-            user.latitude = float(data['latitude']) if data['latitude'] else None
-        if 'longitude' in data:
-            user.longitude = float(data['longitude']) if data['longitude'] else None
+        data = payload.model_dump(exclude_unset=True)
+        for field, value in data.items():
+            setattr(user, field, value)
 
         db.session.commit()
 
@@ -305,6 +285,7 @@ def upload_profile_image():
 
 
 @bp.route('/api/v1/users/map', methods=['GET'])
+@limiter.limit("60/minute", key_func=get_remote_address)
 def get_users_for_map():
     """Obtener todos los usuarios con ubicación para el mapa global (respetando privacidad)"""
     try:
@@ -626,6 +607,7 @@ def haversine_distance(lat1, lon1, lat2, lon2):
 
 
 @bp.route('/api/v1/users/search', methods=['GET'])
+@limiter.limit("60/minute", key_func=get_remote_address)
 def advanced_search():
     """
     Búsqueda avanzada de usuarios con filtros:

--- a/containers/backend/requirements.txt
+++ b/containers/backend/requirements.txt
@@ -24,3 +24,4 @@ flask-limiter
 flask-caching
 py-vapid
 pywebpush
+pydantic>=2.0,<3.0

--- a/containers/caddy/Caddyfile
+++ b/containers/caddy/Caddyfile
@@ -2,9 +2,37 @@
 
 }
 
-# Subdominio para la API, apunta al backend
+# Bloque reutilizable con headers de seguridad aplicados por defecto en
+# todas las respuestas. Ajustar `Content-Security-Policy` si se añaden
+# nuevos orígenes (imágenes remotas, analytics, etc.).
+(security_headers) {
+    header {
+        # Forzar HTTPS por 180 días y permitir preload.
+        Strict-Transport-Security "max-age=15552000; includeSubDomains; preload"
+        # Evitar que el sitio sea embebido en iframes de terceros.
+        X-Frame-Options "DENY"
+        # Evitar MIME-sniffing.
+        X-Content-Type-Options "nosniff"
+        # Referrer restrictivo pero compatible con OAuth flows.
+        Referrer-Policy "strict-origin-when-cross-origin"
+        # Deshabilitar APIs sensibles por defecto.
+        Permissions-Policy "camera=(), microphone=(), geolocation=(self), payment=(), usb=(), interest-cohort=()"
+        # Cross-Origin isolation razonable (sin romper recursos externos).
+        Cross-Origin-Opener-Policy "same-origin"
+        Cross-Origin-Resource-Policy "same-site"
+        # CSP: el frontend SPA sirve assets propios y consume la API.
+        # 'unsafe-inline' se permite sólo para estilos generados por tooling;
+        # scripts requieren `self` (sin eval). Ajustar si se usa inline JS.
+        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.localtalent.es wss://api.localtalent.es; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        # Eliminar header que delata el servidor/versión.
+        -Server
+    }
+}
 
+# Subdominio para la API, apunta al backend
 api.localtalent.es {
+    import security_headers
+
     # Compresión
     encode gzip zstd
 
@@ -20,7 +48,8 @@ api.localtalent.es {
 
 # Dominio principal, apunta al frontend
 localtalent.es {
-    
+    import security_headers
+
     # Compresión
     encode gzip zstd
 


### PR DESCRIPTION
Closes Issue #3 from `ISSUES.md`.

## Summary
- `app/schemas/` with Pydantic v2 models + `@validate_body(Schema)` decorator; all main POST/PUT write endpoints (events, projects, reviews, messaging, profile) now validate input and return 400 with field-level detail.
- `flask-limiter` wired in: 5/min on login/OTP, 3/hour on register/recover, 60/min on public search, 200/min default; Redis as shared storage when `REDIS_URL` is set, disabled under `TESTING`.
- Explicit CORS from `ALLOWED_ORIGINS` env var (comma-separated, `*` rejected); SocketIO uses the same list.
- Security headers in `Caddyfile` applied to both vhosts via a reusable snippet: HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, COOP/CORP, and `-Server`.
- Ownership audit: `projects.update_member_role` and `remove_member` now check that the project exists before dereferencing `creator_id`.

## Test plan
- [ ] Backend imports cleanly (py_compile / ast all modified files passes)
- [ ] `curl -X POST /api/v1/events` with invalid `event_type` returns 400 with `details`
- [ ] 6th login attempt in one minute from same IP returns 429
- [ ] CORS preflight from an origin not in `ALLOWED_ORIGINS` is rejected
- [ ] `curl -I https://localtalent.es` shows HSTS, CSP, X-Frame-Options headers