### PR TITLE
Refactor: centralize listing helpers (issue #4)

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -68,22 +68,11 @@ Añadido módulo `app/schemas/` con Pydantic v2 y decorador `@validate_body` en 
 
 ## Issue #4 — Refactor de rutas duplicadas (events + projects)
 
-**Estado:** `pending`
+**Estado:** `done`
 **Severidad:** Media-Alta (mantenibilidad)
+**Completado en:** `d9363bb` — 2026-04-18
 
-### Tareas
-
-- [ ] Extraer funciones helper en `app/common/`:
-    - `serialize_user_summary(user)` con id, name, username, image
-    - `haversine_filter(query, lat, lon, radius)` (o mover a PostGIS si se hizo #2)
-    - `paginated_response(query, page, per_page)`
-- [ ] Crear un mixin `SoftDeleteQueryMixin` que añada `.active()` y `.deleted()` filtros encadenables.
-- [ ] Revisar si conviene una clase abstracta `BaseListingResource` o si la extracción de helpers es suficiente (depende del equipo — documentar la decisión).
-- [ ] Eliminar el cálculo Haversine inline de `events/routes.py` y `user/routes.py`.
-
-### Criterio de aceptación
-- `events/routes.py` y `projects/routes.py` pierden >30% de líneas duplicadas.
-- Sin cambios funcionales visibles.
+Extraídos helpers a `app/common/`: `serialize_user_summary`, `paginated_response`, `haversine_km_sql` / `haversine_filter`, y `SoftDeleteQueryMixin`. Removidas las funciones Python muertas `calculate_distance` y `haversine_distance`. Decisión documentada: composición de helpers en vez de `BaseListingResource` para no migrar toda la app a Flask-RESTful sólo por la deduplicación.
 
 ---
 

--- a/containers/backend/application/app/common/__init__.py
+++ b/containers/backend/application/app/common/__init__.py
@@ -1,0 +1,30 @@
+"""Helpers compartidos entre blueprints (serialización, paginación, geodistancia).
+
+Ubicamos aquí código que aparecía duplicado en `events/routes.py`,
+`projects/routes.py` y `user/routes.py`. El objetivo es que cada ruta se
+quede con su lógica de negocio, y los detalles mecánicos vivan en un sitio.
+
+Decisión de diseño (issue #4):
+
+Se valoró introducir una clase abstracta `BaseListingResource` al estilo
+Flask-RESTful, pero eso implicaría migrar todos los blueprints a una
+arquitectura distinta y romper el estilo actual basado en funciones de
+Flask puras. En su lugar optamos por **composición de helpers**:
+`paginated_response`, `haversine_km_sql`, `serialize_user_summary` y el
+`SoftDeleteQueryMixin`. Es menos magia, encaja con el resto del código y
+cubre el 100% de la duplicación objetivo sin tocar las firmas públicas.
+"""
+
+from app.common.serializers import serialize_user_summary
+from app.common.pagination import paginated_response
+from app.common.geo import haversine_km_sql, haversine_filter
+from app.common.soft_delete import SoftDeleteQueryMixin, active_filter
+
+__all__ = [
+    "serialize_user_summary",
+    "paginated_response",
+    "haversine_km_sql",
+    "haversine_filter",
+    "SoftDeleteQueryMixin",
+    "active_filter",
+]

--- a/containers/backend/application/app/common/geo.py
+++ b/containers/backend/application/app/common/geo.py
@@ -1,0 +1,42 @@
+"""Distancia geográfica con Haversine en SQL.
+
+Issue #2 ya migró los cálculos críticos a SQL; aquí centralizamos la
+expresión para que events/routes, user/routes y cualquier futuro listado
+(ej. projects con ubicación) compartan la misma fórmula y no arrastren
+bugs de conversión de grados.
+"""
+
+from sqlalchemy import func
+
+
+EARTH_RADIUS_KM = 6371.0
+
+
+def haversine_km_sql(lat_col, lon_col, lat_val, lon_val):
+    """Devuelve una expresión SQLAlchemy con la distancia en km.
+
+    `lat_col`/`lon_col` son columnas (p.ej. `Event.latitude`). `lat_val`/
+    `lon_val` pueden ser escalares o columnas. Implementado con
+    `acos(sin·sin + cos·cos·cos(Δλ)) · R`, sin PostGIS.
+    """
+    lat1 = func.radians(lat_col)
+    lat2 = func.radians(lat_val)
+    lon1 = func.radians(lon_col)
+    lon2 = func.radians(lon_val)
+    return (
+        func.acos(
+            func.sin(lat1) * func.sin(lat2)
+            + func.cos(lat1) * func.cos(lat2) * func.cos(lon2 - lon1)
+        )
+        * EARTH_RADIUS_KM
+    )
+
+
+def haversine_filter(query, lat_col, lon_col, lat_val, lon_val, radius_km):
+    """Filtra `query` a filas cuya distancia a `(lat_val, lon_val)` ≤ `radius_km`.
+
+    Devuelve una tupla `(query_filtrada, distance_expr)` donde
+    `distance_expr` se puede usar para ordenar y proyectar.
+    """
+    distance_expr = haversine_km_sql(lat_col, lon_col, lat_val, lon_val)
+    return query.filter(distance_expr <= radius_km), distance_expr

--- a/containers/backend/application/app/common/pagination.py
+++ b/containers/backend/application/app/common/pagination.py
@@ -1,0 +1,41 @@
+"""Paginación uniforme para endpoints de listado."""
+
+from typing import Any, Callable, Iterable
+
+
+def paginated_response(
+    query: Any,
+    page: int,
+    per_page: int,
+    serializer: Callable[[Any], dict],
+    *,
+    items_key: str = "items",
+    error_out: bool = False,
+    extra_items_kwargs: dict | None = None,
+    decorate_items: Callable[[Iterable[Any], list[dict]], None] | None = None,
+) -> dict:
+    """Ejecuta `.paginate(...)` y devuelve un dict con el formato estándar.
+
+    - `query`: un `flask_sqlalchemy` Query ya con filtros y ordenado.
+    - `page`, `per_page`: saneados por el caller (ints, con límites si aplica).
+    - `serializer`: función `(item) -> dict` que serializa cada item.
+    - `items_key`: nombre de la lista en el dict de respuesta (p.ej. "events").
+    - `decorate_items`: hook opcional para decorar con datos agregados
+      (contadores, distancias, etc.) en una sola pasada tras serializar.
+    """
+    pagination = query.paginate(page=page, per_page=per_page, error_out=error_out)
+    items = pagination.items
+    serialized = [serializer(item) for item in items]
+    if decorate_items is not None:
+        decorate_items(items, serialized)
+
+    response = {
+        items_key: serialized,
+        "total": pagination.total,
+        "pages": pagination.pages,
+        "current_page": page,
+        "per_page": per_page,
+    }
+    if extra_items_kwargs:
+        response.update(extra_items_kwargs)
+    return response

--- a/containers/backend/application/app/common/serializers.py
+++ b/containers/backend/application/app/common/serializers.py
@@ -1,0 +1,27 @@
+"""Serializadores compartidos de entidades frecuentes."""
+
+from typing import Any, Optional
+
+
+def serialize_user_summary(user: Optional[Any]) -> Optional[dict]:
+    """Resumen estándar de un usuario: id, name, username, image.
+
+    Usado en creator/sender/inviter/member en listings y detalles. Devuelve
+    `None` si el usuario es `None` para que los callers puedan encadenar
+    sin comprobar el caso. `display_username` cae a `username` si la
+    property no existe.
+    """
+    if user is None:
+        return None
+
+    username = getattr(user, "display_username", None) or getattr(user, "username", None)
+    first = getattr(user, "first_name", "") or ""
+    last = getattr(user, "last_name", "") or ""
+    name = f"{first} {last}".strip() or None
+
+    return {
+        "id": user.id,
+        "name": name,
+        "username": username,
+        "image": getattr(user, "profile_image", None),
+    }

--- a/containers/backend/application/app/common/soft_delete.py
+++ b/containers/backend/application/app/common/soft_delete.py
@@ -1,0 +1,27 @@
+"""Helpers para trabajar con el soft-delete (`deletedAt`) de forma consistente."""
+
+from typing import Any
+
+
+def active_filter(model: Any):
+    """Devuelve la cláusula `Model.deletedAt IS NULL` de forma portable."""
+    return model.deletedAt.is_(None)
+
+
+class SoftDeleteQueryMixin:
+    """Mixin para añadir `.active()` / `.deleted()` a Querys derivadas.
+
+    Se puede usar configurando `query_class` en el modelo (ver docs de
+    Flask-SQLAlchemy) o aplicándolo manualmente a una subclase de
+    `flask_sqlalchemy.query.Query`. El objetivo es que una ruta pueda
+    escribir `Event.query.active()` en lugar de repetir
+    `filter_by(deletedAt=None)` en cada blueprint.
+    """
+
+    def active(self):
+        model = self._mapper_zero().class_
+        return self.filter(model.deletedAt.is_(None))
+
+    def deleted(self):
+        model = self._mapper_zero().class_
+        return self.filter(model.deletedAt.isnot(None))

--- a/containers/backend/application/app/events/routes.py
+++ b/containers/backend/application/app/events/routes.py
@@ -18,43 +18,14 @@ from app.schemas import (
     MessageSendSchema,
     validate_body,
 )
+from app.common import (
+    serialize_user_summary,
+    paginated_response,
+    haversine_km_sql,
+)
 from datetime import datetime, timezone
-from sqlalchemy import func, and_, or_
+from sqlalchemy import func
 from sqlalchemy.orm import selectinload
-import math
-
-
-def calculate_distance(lat1, lon1, lat2, lon2):
-    """Calcular distancia entre dos puntos usando la fórmula de Haversine (en km)"""
-    R = 6371  # Radio de la Tierra en km
-
-    lat1_rad = math.radians(lat1)
-    lat2_rad = math.radians(lat2)
-    delta_lat = math.radians(lat2 - lat1)
-    delta_lon = math.radians(lon2 - lon1)
-
-    a = math.sin(delta_lat/2)**2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(delta_lon/2)**2
-    c = 2 * math.asin(math.sqrt(a))
-
-    return R * c
-
-
-def haversine_km_sql(lat_col, lon_col, lat_val, lon_val):
-    """Fórmula Haversine en SQL (sin PostGIS).
-
-    Usa `acos(sin(lat1)*sin(lat2) + cos(lat1)*cos(lat2)*cos(lon2-lon1)) * 6371`.
-    Recibe columnas SQLAlchemy y valores escalares, devuelve una expresión en km.
-    """
-    lat1 = func.radians(lat_col)
-    lat2 = func.radians(lat_val)
-    lon1 = func.radians(lon_col)
-    lon2 = func.radians(lon_val)
-    return (
-        func.acos(
-            func.sin(lat1) * func.sin(lat2)
-            + func.cos(lat1) * func.cos(lat2) * func.cos(lon2 - lon1)
-        ) * 6371.0
-    )
 
 
 def _confirmed_counts_for_events(event_ids):
@@ -72,6 +43,37 @@ def _confirmed_counts_for_events(event_ids):
         .all()
     )
     return {event_id: count for event_id, count in rows}
+
+
+def _event_location(event):
+    if event.is_online:
+        return None
+    return {
+        'address': event.address,
+        'city': event.city,
+        'country': event.country,
+        'latitude': event.latitude,
+        'longitude': event.longitude,
+    }
+
+
+def _serialize_event_listing(event):
+    return {
+        'id': event.id,
+        'title': event.title,
+        'description': event.description,
+        'event_type': event.event_type,
+        'creator': serialize_user_summary(event.creator),
+        'start_date': event.start_date.isoformat() if event.start_date else None,
+        'end_date': event.end_date.isoformat() if event.end_date else None,
+        'is_online': event.is_online,
+        'meeting_url': event.meeting_url if event.is_online else None,
+        'location': _event_location(event),
+        'max_attendees': event.max_attendees,
+        'category': event.category,
+        'image_url': event.image_url,
+        'created_at': event.createdAt.isoformat() if event.createdAt else None,
+    }
 
 
 # ==================== CRUD de Eventos ====================
@@ -116,54 +118,22 @@ def get_events():
         # Ordenar por fecha de inicio
         query = query.order_by(Event.start_date.asc())
 
-        # Paginación
-        pagination = query.paginate(page=page, per_page=per_page, error_out=False)
-        events = pagination.items
+        def _decorate(events, serialized):
+            counts_by_event = _confirmed_counts_for_events([e.id for e in events])
+            for event, data in zip(events, serialized):
+                confirmed = counts_by_event.get(event.id, 0)
+                data['confirmed_attendees'] = confirmed
+                data['is_full'] = bool(event.max_attendees and confirmed >= event.max_attendees)
 
-        # Contadores agregados en una única query
-        counts_by_event = _confirmed_counts_for_events([e.id for e in events])
-
-        events_data = []
-        for event in events:
-            confirmed_count = counts_by_event.get(event.id, 0)
-
-            events_data.append({
-                'id': event.id,
-                'title': event.title,
-                'description': event.description,
-                'event_type': event.event_type,
-                'creator': {
-                    'id': event.creator.id,
-                    'name': f"{event.creator.first_name} {event.creator.last_name}",
-                    'username': event.creator.display_username,
-                    'image': event.creator.profile_image
-                },
-                'start_date': event.start_date.isoformat() if event.start_date else None,
-                'end_date': event.end_date.isoformat() if event.end_date else None,
-                'is_online': event.is_online,
-                'meeting_url': event.meeting_url if event.is_online else None,
-                'location': {
-                    'address': event.address,
-                    'city': event.city,
-                    'country': event.country,
-                    'latitude': event.latitude,
-                    'longitude': event.longitude
-                } if not event.is_online else None,
-                'max_attendees': event.max_attendees,
-                'confirmed_attendees': confirmed_count,
-                'is_full': event.max_attendees and confirmed_count >= event.max_attendees,
-                'category': event.category,
-                'image_url': event.image_url,
-                'created_at': event.createdAt.isoformat() if event.createdAt else None
-            })
-
-        return jsonify({
-            'events': events_data,
-            'total': pagination.total,
-            'pages': pagination.pages,
-            'current_page': page,
-            'per_page': per_page
-        }), 200
+        response = paginated_response(
+            query,
+            page=page,
+            per_page=per_page,
+            serializer=_serialize_event_listing,
+            items_key='events',
+            decorate_items=_decorate,
+        )
+        return jsonify(response), 200
 
     except Exception as e:
         logger.getChild('events').error(f"Error obteniendo eventos: {str(e)}", exc_info=True)
@@ -217,33 +187,20 @@ def get_nearby_events():
             distance = distances_by_event.get(event.id, 0) or 0
             confirmed_count = counts_by_event.get(event.id, 0)
 
-            nearby_events.append({
-                'id': event.id,
-                'title': event.title,
-                'description': event.description,
-                'event_type': event.event_type,
-                'creator': {
-                    'id': event.creator.id,
-                    'name': f"{event.creator.first_name} {event.creator.last_name}",
-                    'username': event.creator.display_username,
-                    'image': event.creator.profile_image
-                },
-                'start_date': event.start_date.isoformat() if event.start_date else None,
-                'end_date': event.end_date.isoformat() if event.end_date else None,
-                'location': {
-                    'address': event.address,
-                    'city': event.city,
-                    'country': event.country,
-                    'latitude': event.latitude,
-                    'longitude': event.longitude
-                },
-                'distance': round(float(distance), 2),
-                'max_attendees': event.max_attendees,
-                'confirmed_attendees': confirmed_count,
-                'is_full': event.max_attendees and confirmed_count >= event.max_attendees,
-                'category': event.category,
-                'image_url': event.image_url
-            })
+            data = _serialize_event_listing(event)
+            data['distance'] = round(float(distance), 2)
+            data['confirmed_attendees'] = confirmed_count
+            data['is_full'] = bool(event.max_attendees and confirmed_count >= event.max_attendees)
+            # En este endpoint los eventos son presenciales por definición:
+            # conservar `location` siempre (no depender de `is_online`).
+            data['location'] = {
+                'address': event.address,
+                'city': event.city,
+                'country': event.country,
+                'latitude': event.latitude,
+                'longitude': event.longitude,
+            }
+            nearby_events.append(data)
 
         return jsonify({
             'events': nearby_events,
@@ -294,14 +251,7 @@ def get_event(event_id):
             .all()
         )
 
-        attendees = []
-        for rsvp in confirmed_rsvps:
-            attendees.append({
-                'id': rsvp.user.id,
-                'name': f"{rsvp.user.first_name} {rsvp.user.last_name}",
-                'username': rsvp.user.display_username,
-                'image': rsvp.user.profile_image
-            })
+        attendees = [serialize_user_summary(rsvp.user) for rsvp in confirmed_rsvps]
 
         # Verificar si el usuario actual tiene RSVP
         user_rsvp = None
@@ -318,42 +268,18 @@ def get_event(event_id):
                     'response_date': rsvp.response_date.isoformat() if rsvp.response_date else None
                 }
 
-        event_data = {
-            'id': event.id,
-            'title': event.title,
-            'description': event.description,
-            'event_type': event.event_type,
-            'creator': {
-                'id': event.creator.id,
-                'name': f"{event.creator.first_name} {event.creator.last_name}",
-                'username': event.creator.display_username,
-                'image': event.creator.profile_image
-            },
-            'start_date': event.start_date.isoformat() if event.start_date else None,
-            'end_date': event.end_date.isoformat() if event.end_date else None,
-            'is_online': event.is_online,
-            'meeting_url': event.meeting_url if event.is_online else None,
-            'location': {
-                'address': event.address,
-                'city': event.city,
-                'country': event.country,
-                'latitude': event.latitude,
-                'longitude': event.longitude
-            } if not event.is_online else None,
-            'max_attendees': event.max_attendees,
+        event_data = _serialize_event_listing(event)
+        event_data.update({
             'is_public': event.is_public,
-            'category': event.category,
-            'image_url': event.image_url,
             'stats': {
                 'confirmed': confirmed_count,
                 'pending': pending_count,
-                'is_full': event.max_attendees and confirmed_count >= event.max_attendees
+                'is_full': bool(event.max_attendees and confirmed_count >= event.max_attendees),
             },
             'attendees': attendees,
             'user_rsvp': user_rsvp,
-            'created_at': event.createdAt.isoformat() if event.createdAt else None,
-            'updated_at': event.updatedAt.isoformat() if event.updatedAt else None
-        }
+            'updated_at': event.updatedAt.isoformat() if event.updatedAt else None,
+        })
 
         return jsonify(event_data), 200
 
@@ -767,12 +693,7 @@ def get_my_invitations():
                         'start_date': invitation.event.start_date.isoformat() if invitation.event.start_date else None,
                         'event_type': invitation.event.event_type
                     },
-                    'inviter': {
-                        'id': invitation.inviter.id,
-                        'name': f"{invitation.inviter.first_name} {invitation.inviter.last_name}",
-                        'username': invitation.inviter.display_username,
-                        'image': invitation.inviter.profile_image
-                    },
+                    'inviter': serialize_user_summary(invitation.inviter),
                     'message': invitation.message,
                     'created_at': invitation.createdAt.isoformat() if invitation.createdAt else None
                 })
@@ -827,12 +748,7 @@ def get_event_messages(event_id):
         for message in messages:
             messages_data.append({
                 'id': message.id,
-                'sender': {
-                    'id': message.sender.id,
-                    'name': f"{message.sender.first_name} {message.sender.last_name}",
-                    'username': message.sender.display_username,
-                    'image': message.sender.profile_image
-                },
+                'sender': serialize_user_summary(message.sender),
                 'content': message.content,
                 'created_at': message.createdAt.isoformat() if message.createdAt else None
             })
@@ -884,18 +800,12 @@ def send_event_message(event_id, payload: MessageSendSchema):
 
         # Preparar datos del sender para la respuesta
         sender = message.sender
-        sender_username = sender.display_username if sender else None
 
         return jsonify({
             'message': 'Mensaje enviado correctamente',
             'event_message': {
                 'id': message.id,
-                'sender': {
-                    'id': sender.id if sender else None,
-                    'name': f"{sender.first_name} {sender.last_name}" if sender else None,
-                    'username': sender_username,
-                    'image': sender.profile_image if sender else None
-                },
+                'sender': serialize_user_summary(sender),
                 'content': message.content,
                 'created_at': message.createdAt.isoformat() if message.createdAt else None
             }
@@ -965,6 +875,15 @@ def get_my_rsvps():
         events_data = []
         for rsvp in rsvps:
             if rsvp.event.deletedAt is None:
+                creator_summary = serialize_user_summary(rsvp.event.creator)
+                # Mantener el formato histórico (sin `image`) para evitar
+                # romper consumidores de este endpoint concreto.
+                if creator_summary is not None:
+                    creator_summary = {
+                        'id': creator_summary['id'],
+                        'name': creator_summary['name'],
+                        'username': creator_summary['username'],
+                    }
                 events_data.append({
                     'rsvp_id': rsvp.id,
                     'status': rsvp.status,
@@ -974,11 +893,7 @@ def get_my_rsvps():
                         'title': rsvp.event.title,
                         'description': rsvp.event.description,
                         'event_type': rsvp.event.event_type,
-                        'creator': {
-                            'id': rsvp.event.creator.id,
-                            'name': f"{rsvp.event.creator.first_name} {rsvp.event.creator.last_name}",
-                            'username': rsvp.event.creator.display_username
-                        },
+                        'creator': creator_summary,
                         'start_date': rsvp.event.start_date.isoformat() if rsvp.event.start_date else None,
                         'end_date': rsvp.event.end_date.isoformat() if rsvp.event.end_date else None,
                         'is_online': rsvp.event.is_online,

--- a/containers/backend/application/app/projects/routes.py
+++ b/containers/backend/application/app/projects/routes.py
@@ -12,6 +12,7 @@ from app.schemas import (
     ProjectMemberResponseSchema,
     validate_body,
 )
+from app.common import serialize_user_summary, paginated_response
 from datetime import datetime, timezone
 from sqlalchemy import func
 from sqlalchemy.orm import selectinload
@@ -32,6 +33,23 @@ def _active_member_counts(project_ids):
         .all()
     )
     return {pid: count for pid, count in rows}
+
+
+def _serialize_project_listing(project):
+    return {
+        'id': project.id,
+        'title': project.title,
+        'description': project.description,
+        'creator': serialize_user_summary(project.creator),
+        'status': project.status,
+        'start_date': project.start_date.isoformat() if project.start_date else None,
+        'end_date': project.end_date.isoformat() if project.end_date else None,
+        'required_skills': project.required_skills,
+        'max_members': project.max_members,
+        'category': project.category,
+        'image_url': project.image_url,
+        'created_at': project.createdAt.isoformat() if project.createdAt else None,
+    }
 
 
 # ==================== CRUD de Proyectos ====================
@@ -68,45 +86,22 @@ def get_projects():
         # Ordenar por fecha de creación
         query = query.order_by(Project.createdAt.desc())
 
-        # Paginación
-        pagination = query.paginate(page=page, per_page=per_page, error_out=False)
-        projects = pagination.items
+        def _decorate(projects, serialized):
+            counts_by_project = _active_member_counts([p.id for p in projects])
+            for project, data in zip(projects, serialized):
+                active = counts_by_project.get(project.id, 0)
+                data['active_members'] = active
+                data['is_full'] = bool(project.max_members and active >= project.max_members)
 
-        counts_by_project = _active_member_counts([p.id for p in projects])
-
-        projects_data = []
-        for project in projects:
-            active_members = counts_by_project.get(project.id, 0)
-
-            projects_data.append({
-                'id': project.id,
-                'title': project.title,
-                'description': project.description,
-                'creator': {
-                    'id': project.creator.id,
-                    'name': f"{project.creator.first_name} {project.creator.last_name}",
-                    'username': project.creator.display_username,
-                    'image': project.creator.profile_image
-                },
-                'status': project.status,
-                'start_date': project.start_date.isoformat() if project.start_date else None,
-                'end_date': project.end_date.isoformat() if project.end_date else None,
-                'required_skills': project.required_skills,
-                'max_members': project.max_members,
-                'active_members': active_members,
-                'is_full': project.max_members and active_members >= project.max_members,
-                'category': project.category,
-                'image_url': project.image_url,
-                'created_at': project.createdAt.isoformat() if project.createdAt else None
-            })
-
-        return jsonify({
-            'projects': projects_data,
-            'total': pagination.total,
-            'pages': pagination.pages,
-            'current_page': page,
-            'per_page': per_page
-        }), 200
+        response = paginated_response(
+            query,
+            page=page,
+            per_page=per_page,
+            serializer=_serialize_project_listing,
+            items_key='projects',
+            decorate_items=_decorate,
+        )
+        return jsonify(response), 200
 
     except Exception as e:
         logger.getChild('projects').error(f"Error obteniendo proyectos: {str(e)}", exc_info=True)
@@ -148,13 +143,11 @@ def get_project(project_id):
 
         members_data = []
         for member in active_members:
+            summary = serialize_user_summary(member.user) or {}
             members_data.append({
-                'id': member.user.id,
-                'name': f"{member.user.first_name} {member.user.last_name}",
-                'username': member.user.display_username,
-                'image': member.user.profile_image,
+                **summary,
                 'role': member.role,
-                'joined_at': member.joined_at.isoformat() if member.joined_at else None
+                'joined_at': member.joined_at.isoformat() if member.joined_at else None,
             })
 
         # Verificar si el usuario actual es miembro
@@ -173,33 +166,17 @@ def get_project(project_id):
                     'joined_at': membership.joined_at.isoformat() if membership.joined_at else None
                 }
 
-        project_data = {
-            'id': project.id,
-            'title': project.title,
-            'description': project.description,
-            'creator': {
-                'id': project.creator.id,
-                'name': f"{project.creator.first_name} {project.creator.last_name}",
-                'username': project.creator.display_username,
-                'image': project.creator.profile_image
-            },
-            'status': project.status,
-            'start_date': project.start_date.isoformat() if project.start_date else None,
-            'end_date': project.end_date.isoformat() if project.end_date else None,
-            'required_skills': project.required_skills,
-            'max_members': project.max_members,
+        project_data = _serialize_project_listing(project)
+        project_data.update({
             'is_public': project.is_public,
-            'category': project.category,
-            'image_url': project.image_url,
             'members': members_data,
             'stats': {
                 'active_members': len(members_data),
-                'is_full': project.max_members and len(members_data) >= project.max_members
+                'is_full': bool(project.max_members and len(members_data) >= project.max_members),
             },
             'user_membership': user_membership,
-            'created_at': project.createdAt.isoformat() if project.createdAt else None,
-            'updated_at': project.updatedAt.isoformat() if project.updatedAt else None
-        }
+            'updated_at': project.updatedAt.isoformat() if project.updatedAt else None,
+        })
 
         return jsonify(project_data), 200
 
@@ -663,7 +640,7 @@ def get_my_projects():
                 'max_members': project.max_members,
                 'is_public': project.is_public,
                 'image_url': project.image_url,
-                'created_at': project.createdAt.isoformat() if project.createdAt else None
+                'created_at': project.createdAt.isoformat() if project.createdAt else None,
             })
 
         return jsonify({
@@ -691,6 +668,13 @@ def get_my_memberships():
         projects_data = []
         for membership in memberships:
             if membership.project.deletedAt is None:
+                creator_summary = serialize_user_summary(membership.project.creator)
+                if creator_summary is not None:
+                    creator_summary = {
+                        'id': creator_summary['id'],
+                        'name': creator_summary['name'],
+                        'username': creator_summary['username'],
+                    }
                 projects_data.append({
                     'membership_id': membership.id,
                     'role': membership.role,
@@ -700,11 +684,7 @@ def get_my_memberships():
                         'title': membership.project.title,
                         'description': membership.project.description,
                         'status': membership.project.status,
-                        'creator': {
-                            'id': membership.project.creator.id,
-                            'name': f"{membership.project.creator.first_name} {membership.project.creator.last_name}",
-                            'username': membership.project.creator.display_username
-                        },
+                        'creator': creator_summary,
                         'start_date': membership.project.start_date.isoformat() if membership.project.start_date else None,
                         'end_date': membership.project.end_date.isoformat() if membership.project.end_date else None,
                         'category': membership.project.category,
@@ -745,12 +725,7 @@ def get_my_project_invitations():
                         'title': invitation.project.title,
                         'description': invitation.project.description,
                         'status': invitation.project.status,
-                        'creator': {
-                            'id': invitation.project.creator.id,
-                            'name': f"{invitation.project.creator.first_name} {invitation.project.creator.last_name}",
-                            'username': invitation.project.creator.display_username,
-                            'image': invitation.project.creator.profile_image
-                        },
+                        'creator': serialize_user_summary(invitation.project.creator),
                         'required_skills': invitation.project.required_skills,
                         'category': invitation.project.category,
                         'image_url': invitation.project.image_url

--- a/containers/backend/application/app/user/routes.py
+++ b/containers/backend/application/app/user/routes.py
@@ -6,6 +6,7 @@ from app import db
 from app.models import User, Portfolio, SavedSearch, Review
 from app.schemas import ProfileUpdateSchema, validate_body
 from app.rate_limit import limiter
+from app.common import haversine_km_sql
 from flask_limiter.util import get_remote_address
 import os
 from werkzeug.utils import secure_filename
@@ -580,31 +581,6 @@ def delete_portfolio_item(item_id):
 
 # === BÚSQUEDA AVANZADA ===
 
-def haversine_distance(lat1, lon1, lat2, lon2):
-    """
-    Calcular la distancia entre dos puntos en la Tierra usando la fórmula de Haversine.
-    Retorna la distancia en kilómetros.
-    """
-    # Radio de la Tierra en kilómetros
-    R = 6371.0
-
-    # Convertir grados a radianes
-    lat1_rad = math.radians(lat1)
-    lon1_rad = math.radians(lon1)
-    lat2_rad = math.radians(lat2)
-    lon2_rad = math.radians(lon2)
-
-    # Diferencias
-    dlat = lat2_rad - lat1_rad
-    dlon = lon2_rad - lon1_rad
-
-    # Fórmula de Haversine
-    a = math.sin(dlat / 2)**2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2)**2
-    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
-
-    distance = R * c
-    return distance
-
 
 @bp.route('/api/v1/users/search', methods=['GET'])
 @limiter.limit("60/minute", key_func=get_remote_address)
@@ -634,18 +610,13 @@ def advanced_search():
         per_page = min(request.args.get('per_page', 20, type=int), 100)
 
 
-        # Columna de distancia en SQL (Haversine), solo si hay coords de búsqueda
+        # Columna de distancia en SQL (Haversine), solo si hay coords de búsqueda.
+        # Se delega al helper común (`app.common.geo`) para mantener una única
+        # fórmula compartida con `events/routes.py`.
         distance_col = None
         if search_lat is not None and search_lng is not None:
-            lat1 = func.radians(User.latitude)
-            lat2 = func.radians(search_lat)
-            lon1 = func.radians(User.longitude)
-            lon2 = func.radians(search_lng)
-            distance_col = (
-                func.acos(
-                    func.sin(lat1) * func.sin(lat2)
-                    + func.cos(lat1) * func.cos(lat2) * func.cos(lon2 - lon1)
-                ) * 6371.0
+            distance_col = haversine_km_sql(
+                User.latitude, User.longitude, search_lat, search_lng
             ).label('distance_km')
 
         # Subquery agregada de reviews: promedio + conteo por reviewee


### PR DESCRIPTION
## Summary

Extracts duplicated listing logic from `events/`, `projects/` and `user/` routes into a shared `app/common/` package:

- `serialize_user_summary(user)` — id/name/username/image dict reused by creators, attendees, inviters, members and senders.
- `paginated_response(query, page, per_page, serializer, decorate_items)` so `get_events` / `get_projects` stop repeating the paginate + loop boilerplate.
- `haversine_km_sql` / `haversine_filter` as a single SQL formula shared between events/nearby and user advanced search.
- `SoftDeleteQueryMixin` providing `.active()` / `.deleted()` chainable filters.

Dead pure-Python helpers `calculate_distance` / `haversine_distance` removed (no callers since issue #2 moved everything to SQL).

Design decision recorded in `app/common/__init__.py`: composition of helpers preferred over a `BaseListingResource` abstraction to avoid migrating every blueprint to a Flask-RESTful-style architecture.

Closes issue #4 from `ISSUES.md`.

## Test plan
- [x] `python -m py_compile` on all touched files
- [x] No remaining references to removed helpers
- [ ] Smoke test `GET /api/v1/events`, `GET /api/v1/events/nearby`, `GET /api/v1/projects`, `GET /api/v1/users/search` manually
