### PR TITLE
feat(issue-5): profile views, username change, real digest counts

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -78,22 +78,11 @@ Extraídos helpers a `app/common/`: `serialize_user_summary`, `paginated_respons
 
 ## Issue #5 — Completar features a medias (profile views, digest, username)
 
-**Estado:** `pending`
+**Estado:** `done`
 **Severidad:** Media (features rotas)
+**Completado en:** `ae50bda` — 2026-04-18
 
-### Tareas
-
-- [ ] Nuevo modelo `ProfileView(Base)` con `viewer_id`, `viewed_id`, `viewed_at`, índice en `(viewed_id, viewed_at)`. Migración.
-- [ ] Endpoint `POST /api/v1/users/<id>/view` que registre la visita con deduplicación (máximo una vista por viewer/viewed cada 24h).
-- [ ] Hook en frontend: cuando se carga `/profile/<username>` llamar al endpoint.
-- [ ] En `email_tasks.send_weekly_digests`, sustituir `profile_views: 0` por el conteo real de la última semana.
-- [ ] Notificación realtime cuando alguien ve tu perfil (opt-in en settings — respetar `email_notifications` y añadir nuevo flag `notify_profile_views`).
-- [ ] Endpoint `PUT /api/v1/users/me/username` con validación de unicidad y formato (`^[a-z0-9_-]{3,30}$`). Sólo editable 1 vez cada 30 días.
-- [ ] Página en frontend para cambiar username con feedback de disponibilidad en tiempo real.
-
-### Criterio de aceptación
-- El email de digest muestra views reales.
-- Usuario puede cambiar username desde la UI.
+Añadido modelo `ProfileView` + migración `13_profile_views_username` con índices `(viewed_id, viewed_at)` y `(viewer_id, viewed_id, viewed_at)`. Nuevo endpoint `POST /api/v1/users/<id>/view` con dedup 24h. Hook de registro en la carga de `/auth/user/<username>`. `email_tasks.send_weekly_digests` muestra `profile_views` reales (únicos por viewer/última semana). Nuevo flag `notify_profile_views` en `User` con toggle en `/api/v1/notifications/preferences` y en la UI de `NotificationSettings`; notifica in-app al `viewed` cuando está activo. Endpoint `PUT /api/v1/users/me/username` con validación de formato/unicidad y cooldown de 30 días, y `GET /api/v1/users/me/username/availability`. Componente `UsernameSettings` con feedback de disponibilidad en tiempo real embebido en la página de perfil.
 
 ---
 

--- a/containers/backend/application/app/email_tasks.py
+++ b/containers/backend/application/app/email_tasks.py
@@ -2,7 +2,7 @@
 Tareas de Celery para envío de emails y notificaciones periódicas
 """
 from app import create_app, db
-from app.models import User, Notification, Message, Conversation, Event, EventRSVP
+from app.models import User, Notification, Message, Conversation, Event, EventRSVP, ProfileView
 from app.email_service import (
     send_new_users_in_city_email,
     send_event_reminder_email,
@@ -176,8 +176,17 @@ def send_weekly_digests():
                         User.createdAt >= week_ago
                     ).count()
 
+                # Vistas de perfil recibidas en la última semana (únicas por viewer)
+                profile_views = db.session.query(
+                    func.count(func.distinct(ProfileView.viewer_id))
+                ).filter(
+                    ProfileView.viewed_id == user.id,
+                    ProfileView.viewed_at >= week_ago,
+                    ProfileView.deletedAt.is_(None),
+                ).scalar() or 0
+
                 stats = {
-                    'profile_views': 0,  # TODO: implementar cuando exista ProfileView model
+                    'profile_views': int(profile_views),
                     'new_messages': new_messages,
                     'new_events': new_events,
                     'new_users_in_city': new_users_in_city

--- a/containers/backend/application/app/models.py
+++ b/containers/backend/application/app/models.py
@@ -123,7 +123,7 @@ def setup_base():
     # Modelos activos (sin organizaciones)
     for model in [User, JWTToken, Feedback, Portfolio, Message, Conversation, Notification, Review, SavedSearch,
                   Event, Project, EventRSVP, ProjectMember, EventInvitation, EventMessage,
-                  BlockedUser, Report, VerificationRequest]:
+                  BlockedUser, Report, VerificationRequest, ProfileView]:
         event.listen(model, 'after_insert', lambda m, c, t: record_base(m, c, t, "INSERT"))
         event.listen(model, 'after_update', lambda m, c, t: record_base(m, c, t, "UPDATE"))
 
@@ -223,7 +223,7 @@ def record_audit(mapper, connection, target):
 def setup_audit():
     for model in [User, Feedback, Portfolio, Message, Conversation, Notification, Review, SavedSearch,
                   Event, Project, EventRSVP, ProjectMember, EventInvitation, EventMessage,
-                  BlockedUser, Report, VerificationRequest]:
+                  BlockedUser, Report, VerificationRequest, ProfileView]:
         event.listen(model, 'after_insert', record_audit)
         event.listen(model, 'after_update', record_audit)
 
@@ -299,7 +299,11 @@ class User(Base, UserMixin):
 
     # Campos de notificaciones
     email_notifications = db.Column(db.Boolean, default=True, nullable=False)  # Notificaciones por email habilitadas
+    notify_profile_views = db.Column(db.Boolean, default=False, nullable=False)  # Opt-in notificación al ver perfil
     push_subscription = db.Column(JSONB, nullable=True)  # Suscripción para web push notifications
+
+    # Último cambio de username (para rate-limit de 30 días)
+    username_changed_at = db.Column(db.DateTime, nullable=True)
 
     # Campo de roles especiales (conservado)
     special_roles = db.Column(db.ARRAY(db.String), default=[])
@@ -923,6 +927,28 @@ class VerificationRequest(Base):
 
     def __repr__(self):
         return f'<VerificationRequest {self.id} - User {self.user_id}, Status: {self.status}>'
+
+
+# ProfileView Model - Visitas a perfiles (Issue #5)
+class ProfileView(Base):
+    __tablename__ = 'profile_view'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    viewer_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False)
+    viewed_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False)
+    viewed_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    viewer = db.relationship('User', foreign_keys=[viewer_id], backref='profile_views_made')
+    viewed = db.relationship('User', foreign_keys=[viewed_id], backref='profile_views_received')
+
+    __table_args__ = (
+        db.Index('idx_profile_view_viewed_viewed_at', 'viewed_id', 'viewed_at'),
+        db.Index('idx_profile_view_viewer_viewed_viewed_at', 'viewer_id', 'viewed_id', 'viewed_at'),
+        db.CheckConstraint('viewer_id != viewed_id', name='no_self_profile_view'),
+    )
+
+    def __repr__(self):
+        return f'<ProfileView {self.id} - viewer {self.viewer_id} -> viewed {self.viewed_id}>'
 
 
 # Registrar listeners una vez que todos los modelos (incluido Feedback) están definidos

--- a/containers/backend/application/app/notifications/routes.py
+++ b/containers/backend/application/app/notifications/routes.py
@@ -245,6 +245,7 @@ def get_notification_preferences():
     try:
         return jsonify({
             'email_notifications': current_user.email_notifications,
+            'notify_profile_views': bool(getattr(current_user, 'notify_profile_views', False)),
             'push_notifications': current_user.push_subscription is not None
         }), 200
     except Exception as e:
@@ -257,16 +258,20 @@ def get_notification_preferences():
 def update_notification_preferences():
     """Actualizar preferencias de notificaciones"""
     try:
-        data = request.get_json()
+        data = request.get_json() or {}
 
         if 'email_notifications' in data:
             current_user.email_notifications = bool(data['email_notifications'])
+
+        if 'notify_profile_views' in data:
+            current_user.notify_profile_views = bool(data['notify_profile_views'])
 
         db.session.commit()
 
         return jsonify({
             'message': 'Preferencias actualizadas',
-            'email_notifications': current_user.email_notifications
+            'email_notifications': current_user.email_notifications,
+            'notify_profile_views': bool(getattr(current_user, 'notify_profile_views', False)),
         }), 200
     except Exception as e:
         db.session.rollback()

--- a/containers/backend/application/app/user/routes.py
+++ b/containers/backend/application/app/user/routes.py
@@ -3,8 +3,8 @@ from flask_login import current_user, login_required
 from app.user import bp
 from app.logger_config import logger
 from app import db
-from app.models import User, Portfolio, SavedSearch, Review
-from app.schemas import ProfileUpdateSchema, validate_body
+from app.models import User, Portfolio, SavedSearch, Review, ProfileView, Notification
+from app.schemas import ProfileUpdateSchema, UsernameUpdateSchema, validate_body
 from app.rate_limit import limiter
 from app.common import haversine_km_sql
 from flask_limiter.util import get_remote_address
@@ -14,7 +14,7 @@ from sqlalchemy import func, or_, and_
 import math
 from app.auth.email import send_delete_account_email
 from flask_login import logout_user
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 # Minimal user blueprint: only session info retained
 
@@ -147,6 +147,7 @@ def get_public_profile(username):
         if not user.is_profile_public:
             # Si el perfil es privado, solo mostrar información muy básica
             return jsonify({
+                'id': user.id,
                 'username': username,
                 'first_name': user.first_name,
                 'last_name': user.last_name,
@@ -174,6 +175,7 @@ def get_public_profile(username):
 
         # Solo devolver información pública
         return jsonify({
+            'id': user.id,
             'username': username,
             'first_name': user.first_name,
             'last_name': user.last_name,
@@ -882,3 +884,174 @@ def update_saved_search(search_id):
         db.session.rollback()
         logger.getChild('user').error(f"Error actualizando búsqueda guardada: {str(e)}", exc_info=True)
         return jsonify({'error': 'Error al actualizar la búsqueda guardada'}), 500
+
+
+# === PROFILE VIEWS (Issue #5) ===
+
+PROFILE_VIEW_DEDUP_HOURS = 24
+
+
+@bp.route('/api/v1/users/<int:user_id>/view', methods=['POST'])
+@login_required
+@limiter.limit("60/minute", key_func=lambda: str(current_user.id) if current_user.is_authenticated else get_remote_address())
+def register_profile_view(user_id: int):
+    """Registrar que el usuario autenticado ha visto el perfil de <user_id>.
+
+    Dedup: una sola visita contabilizada por (viewer, viewed) cada 24h.
+    Notifica al `viewed` si tiene `notify_profile_views` activado.
+    """
+    try:
+        if user_id == current_user.id:
+            return jsonify({'counted': False, 'reason': 'self_view'}), 200
+
+        viewed = db.session.get(User, user_id)
+        if not viewed or viewed.deletedAt is not None or not viewed.is_enabled:
+            return jsonify({'error': 'Usuario no encontrado'}), 404
+
+        since = datetime.now(timezone.utc) - timedelta(hours=PROFILE_VIEW_DEDUP_HOURS)
+        recent = (
+            db.session.query(ProfileView.id)
+            .filter(
+                ProfileView.viewer_id == current_user.id,
+                ProfileView.viewed_id == user_id,
+                ProfileView.viewed_at >= since,
+                ProfileView.deletedAt.is_(None),
+            )
+            .first()
+        )
+
+        if recent:
+            return jsonify({'counted': False, 'reason': 'already_counted'}), 200
+
+        pv = ProfileView(
+            viewer_id=current_user.id,
+            viewed_id=user_id,
+            viewed_at=datetime.now(timezone.utc),
+        )
+        db.session.add(pv)
+
+        if getattr(viewed, 'notify_profile_views', False):
+            viewer_name = f"{current_user.first_name} {current_user.last_name}".strip() or current_user.display_username
+            link_username = current_user.username or ''
+            notif = Notification(
+                user_id=viewed.id,
+                type='profile_view',
+                title='Alguien vió tu perfil',
+                message=f'{viewer_name} acaba de visitar tu perfil',
+                link=f'/auth/user/{link_username}' if link_username else None,
+                data={'viewer_id': current_user.id, 'viewer_username': link_username or None},
+                is_read=False,
+            )
+            db.session.add(notif)
+
+        db.session.commit()
+        return jsonify({'counted': True}), 200
+
+    except Exception as e:
+        db.session.rollback()
+        logger.getChild('user').error(f"Error registrando profile view: {str(e)}", exc_info=True)
+        return jsonify({'error': 'Error interno'}), 500
+
+
+# === USERNAME CHANGE (Issue #5) ===
+
+USERNAME_CHANGE_COOLDOWN_DAYS = 30
+
+
+@bp.route('/api/v1/users/me/username', methods=['PUT'])
+@login_required
+@limiter.limit("5/hour", key_func=lambda: str(current_user.id) if current_user.is_authenticated else get_remote_address())
+@validate_body(UsernameUpdateSchema)
+def update_my_username(payload: UsernameUpdateSchema):
+    """Actualizar el username del usuario autenticado.
+
+    - Validación de formato `^[a-z0-9_-]{3,30}$` (en el schema).
+    - Unicidad comprobada antes de commit.
+    - Sólo editable una vez cada 30 días.
+    """
+    try:
+        new_username = payload.username
+        user = current_user
+
+        if user.username == new_username:
+            return jsonify({
+                'message': 'El username ya es el actual',
+                'username': user.username,
+            }), 200
+
+        now = datetime.now(timezone.utc)
+        last_change = user.username_changed_at
+        if last_change is not None:
+            if last_change.tzinfo is None:
+                last_change = last_change.replace(tzinfo=timezone.utc)
+            cooldown = timedelta(days=USERNAME_CHANGE_COOLDOWN_DAYS)
+            if now - last_change < cooldown:
+                next_change_at = last_change + cooldown
+                return jsonify({
+                    'error': 'Sólo puedes cambiar el username una vez cada 30 días',
+                    'next_change_at': next_change_at.isoformat(),
+                }), 429
+
+        exists = (
+            db.session.query(User.id)
+            .filter(User.username == new_username, User.id != user.id)
+            .first()
+        )
+        if exists:
+            return jsonify({'error': 'Username no disponible'}), 409
+
+        user.username = new_username
+        user.username_changed_at = now
+        db.session.commit()
+
+        return jsonify({
+            'message': 'Username actualizado correctamente',
+            'username': user.username,
+            'next_change_at': (now + timedelta(days=USERNAME_CHANGE_COOLDOWN_DAYS)).isoformat(),
+        }), 200
+
+    except Exception as e:
+        db.session.rollback()
+        logger.getChild('user').error(f"Error actualizando username: {str(e)}", exc_info=True)
+        return jsonify({'error': 'Error al actualizar el username'}), 500
+
+
+@bp.route('/api/v1/users/me/username/availability', methods=['GET'])
+@login_required
+@limiter.limit("30/minute", key_func=lambda: str(current_user.id) if current_user.is_authenticated else get_remote_address())
+def check_username_availability():
+    """Consulta en tiempo real si un username está disponible y con formato válido."""
+    try:
+        raw = (request.args.get('username') or '').strip().lower()
+        try:
+            UsernameUpdateSchema(username=raw)
+        except Exception:
+            return jsonify({
+                'username': raw,
+                'valid_format': False,
+                'available': False,
+                'reason': 'invalid_format',
+            }), 200
+
+        if current_user.username == raw:
+            return jsonify({
+                'username': raw,
+                'valid_format': True,
+                'available': True,
+                'is_current': True,
+            }), 200
+
+        taken = (
+            db.session.query(User.id)
+            .filter(User.username == raw, User.id != current_user.id)
+            .first()
+        )
+        return jsonify({
+            'username': raw,
+            'valid_format': True,
+            'available': taken is None,
+            'is_current': False,
+        }), 200
+    except Exception as e:
+        logger.getChild('user').error(f"Error comprobando username: {str(e)}", exc_info=True)
+        return jsonify({'error': 'Error interno'}), 500

--- a/containers/backend/application/migrations/versions/13_add_profile_views_and_username_tracking.py
+++ b/containers/backend/application/migrations/versions/13_add_profile_views_and_username_tracking.py
@@ -1,0 +1,64 @@
+"""add profile views, notify_profile_views flag and username_changed_at (Issue #5)
+
+Revision ID: 13_profile_views_username
+Revises: 12_add_performance_indexes
+Create Date: 2026-04-18 00:00:00.000000
+
+- Nueva tabla `profile_view` para registrar visitas a perfiles
+  (con deduplicación por ventana horaria a nivel de aplicación).
+- Nuevo flag `notify_profile_views` en `user` para el opt-in de
+  notificaciones cuando alguien ve tu perfil.
+- Nuevo campo `username_changed_at` en `user` para limitar cambios
+  de username a 1 cada 30 días.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '13_profile_views_username'
+down_revision = '12_add_performance_indexes'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'user',
+        sa.Column('notify_profile_views', sa.Boolean(), nullable=False, server_default='false'),
+    )
+    op.add_column(
+        'user',
+        sa.Column('username_changed_at', sa.DateTime(), nullable=True),
+    )
+
+    op.create_table(
+        'profile_view',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('viewer_id', sa.Integer(), nullable=False),
+        sa.Column('viewed_id', sa.Integer(), nullable=False),
+        sa.Column('viewed_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('createdAt', sa.DateTime(), nullable=True),
+        sa.Column('updatedAt', sa.DateTime(), nullable=True),
+        sa.Column('deletedAt', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['viewer_id'], ['user.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['viewed_id'], ['user.id'], ondelete='CASCADE'),
+        sa.CheckConstraint('viewer_id != viewed_id', name='no_self_profile_view'),
+    )
+    op.create_index(
+        'idx_profile_view_viewed_viewed_at',
+        'profile_view',
+        ['viewed_id', 'viewed_at'],
+    )
+    op.create_index(
+        'idx_profile_view_viewer_viewed_viewed_at',
+        'profile_view',
+        ['viewer_id', 'viewed_id', 'viewed_at'],
+    )
+
+
+def downgrade():
+    op.drop_index('idx_profile_view_viewer_viewed_viewed_at', table_name='profile_view')
+    op.drop_index('idx_profile_view_viewed_viewed_at', table_name='profile_view')
+    op.drop_table('profile_view')
+    op.drop_column('user', 'username_changed_at')
+    op.drop_column('user', 'notify_profile_views')

--- a/containers/frontend/src/components/notifications/NotificationSettings.tsx
+++ b/containers/frontend/src/components/notifications/NotificationSettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Bell, Mail } from 'lucide-react'
+import { Bell, Mail, Eye } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
@@ -17,12 +17,14 @@ import { getNotificationPreferences, updateNotificationPreferences } from '@/ser
 
 interface NotificationPreferences {
   email_notifications: boolean
+  notify_profile_views: boolean
   push_notifications: boolean
 }
 
 export function NotificationSettings() {
   const [preferences, setPreferences] = useState<NotificationPreferences>({
     email_notifications: true,
+    notify_profile_views: false,
     push_notifications: false,
   })
   const [isLoading, setIsLoading] = useState(true)
@@ -57,6 +59,7 @@ export function NotificationSettings() {
 
       setPreferences({
         email_notifications: !!data?.email_notifications,
+        notify_profile_views: !!data?.notify_profile_views,
         push_notifications: (data?.push_notifications ?? pushServerStatus) || isPushLocal,
       })
     } catch (error) {
@@ -78,6 +81,22 @@ export function NotificationSettings() {
 
       setPreferences((prev) => ({ ...prev, email_notifications: newValue }))
       toast.success(`Notificaciones por email ${newValue ? 'activadas' : 'desactivadas'}`)
+    } catch (error) {
+      console.error('Error actualizando preferencias:', error)
+      toast.error('Error al actualizar las preferencias')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleProfileViewsToggle = async () => {
+    setIsSaving(true)
+    setLoadError(null)
+    try {
+      const newValue = !preferences.notify_profile_views
+      await updateNotificationPreferences({ notify_profile_views: newValue })
+      setPreferences((prev) => ({ ...prev, notify_profile_views: newValue }))
+      toast.success(`Notificaciones de visitas a tu perfil ${newValue ? 'activadas' : 'desactivadas'}`)
     } catch (error) {
       console.error('Error actualizando preferencias:', error)
       toast.error('Error al actualizar las preferencias')
@@ -194,6 +213,27 @@ export function NotificationSettings() {
               id="email-notifications"
               checked={preferences.email_notifications}
               onCheckedChange={handleEmailToggle}
+              disabled={isSaving}
+            />
+          </div>
+
+          {/* Visitas a mi perfil */}
+          <div className="flex items-center justify-between space-x-4 rounded-lg border p-4">
+            <div className="flex items-start space-x-4">
+              <Eye className="w-6 h-6 text-primary mt-0.5" />
+              <div className="space-y-1 flex-1">
+                <Label htmlFor="notify-profile-views" className="text-base">
+                  Avisarme cuando vean mi perfil
+                </Label>
+                <p className="text-sm text-muted-foreground">
+                  Recibirás una notificación cuando otra persona visite tu perfil. Desactivado por defecto.
+                </p>
+              </div>
+            </div>
+            <Switch
+              id="notify-profile-views"
+              checked={preferences.notify_profile_views}
+              onCheckedChange={handleProfileViewsToggle}
               disabled={isSaving}
             />
           </div>

--- a/containers/frontend/src/components/profile/UsernameSettings.tsx
+++ b/containers/frontend/src/components/profile/UsernameSettings.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useToast } from '@/hooks/use-toast'
+import { Check, Loader2, X } from 'lucide-react'
+
+interface UsernameSettingsProps {
+  currentUsername: string
+  onChanged?: (newUsername: string) => void
+}
+
+const USERNAME_REGEX = /^[a-z0-9_-]{3,30}$/
+
+type Availability =
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | { state: 'invalid'; reason: string }
+  | { state: 'taken' }
+  | { state: 'available' }
+  | { state: 'current' }
+
+export function UsernameSettings({ currentUsername, onChanged }: UsernameSettingsProps) {
+  const { toast } = useToast()
+  const apiUrl = import.meta.env.VITE_REACT_APP_API_URL
+  const [value, setValue] = useState(currentUsername || '')
+  const [saving, setSaving] = useState(false)
+  const [availability, setAvailability] = useState<Availability>({ state: 'idle' })
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    setValue(currentUsername || '')
+  }, [currentUsername])
+
+  const normalized = useMemo(() => value.trim().toLowerCase(), [value])
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (!normalized) {
+      setAvailability({ state: 'idle' })
+      return
+    }
+    if (normalized === currentUsername) {
+      setAvailability({ state: 'current' })
+      return
+    }
+    if (!USERNAME_REGEX.test(normalized)) {
+      setAvailability({
+        state: 'invalid',
+        reason: '3-30 caracteres con minúsculas, dígitos, _ o -',
+      })
+      return
+    }
+
+    setAvailability({ state: 'checking' })
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `${apiUrl}/api/v1/users/me/username/availability?username=${encodeURIComponent(normalized)}`,
+          { credentials: 'include' },
+        )
+        if (!res.ok) throw new Error('check_failed')
+        const data = await res.json()
+        if (!data.valid_format) {
+          setAvailability({ state: 'invalid', reason: 'Formato inválido' })
+        } else if (data.is_current) {
+          setAvailability({ state: 'current' })
+        } else if (data.available) {
+          setAvailability({ state: 'available' })
+        } else {
+          setAvailability({ state: 'taken' })
+        }
+      } catch {
+        setAvailability({ state: 'idle' })
+      }
+    }, 400)
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [normalized, currentUsername, apiUrl])
+
+  const canSave =
+    !saving && availability.state === 'available' && normalized !== currentUsername
+
+  const handleSave = async () => {
+    if (!canSave) return
+    setSaving(true)
+    try {
+      const res = await fetch(`${apiUrl}/api/v1/users/me/username`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ username: normalized }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        let description = data?.error || 'No se pudo actualizar el username'
+        if (res.status === 429 && data?.next_change_at) {
+          const when = new Date(data.next_change_at).toLocaleDateString()
+          description = `Sólo puedes cambiar el username una vez cada 30 días. Próximo cambio disponible: ${when}`
+        }
+        toast({ title: 'No se pudo guardar', description, variant: 'destructive' })
+        return
+      }
+      toast({ title: 'Username actualizado', description: `Ahora eres @${data.username}` })
+      onChanged?.(data.username)
+    } catch {
+      toast({ title: 'Error', description: 'Fallo de red', variant: 'destructive' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const renderStatus = () => {
+    switch (availability.state) {
+      case 'checking':
+        return (
+          <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+            <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+            Comprobando disponibilidad…
+          </span>
+        )
+      case 'available':
+        return (
+          <span className="inline-flex items-center gap-1 text-xs text-green-600">
+            <Check className="w-3 h-3" aria-hidden="true" />
+            Disponible
+          </span>
+        )
+      case 'taken':
+        return (
+          <span className="inline-flex items-center gap-1 text-xs text-destructive">
+            <X className="w-3 h-3" aria-hidden="true" />
+            Ya está en uso
+          </span>
+        )
+      case 'invalid':
+        return (
+          <span className="inline-flex items-center gap-1 text-xs text-destructive">
+            <X className="w-3 h-3" aria-hidden="true" />
+            {availability.reason}
+          </span>
+        )
+      case 'current':
+        return (
+          <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+            Es tu username actual
+          </span>
+        )
+      default:
+        return null
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Nombre de usuario</CardTitle>
+        <CardDescription>
+          Es tu identificador público (@{currentUsername}). Sólo puedes cambiarlo una vez cada 30 días.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="space-y-1">
+          <Label htmlFor="username-input">Nuevo username</Label>
+          <div className="flex items-center gap-2">
+            <Input
+              id="username-input"
+              value={value}
+              onChange={(e) => setValue(e.target.value.toLowerCase())}
+              placeholder="ej: ana-perez"
+              aria-describedby="username-status"
+              maxLength={30}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <Button onClick={handleSave} disabled={!canSave}>
+              {saving && <Loader2 className="w-4 h-4 mr-2 animate-spin" aria-hidden="true" />}
+              Guardar
+            </Button>
+          </div>
+          <div id="username-status" aria-live="polite" className="min-h-[1.25rem]">
+            {renderStatus()}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/containers/frontend/src/routes/auth/user/$username.lazy.tsx
+++ b/containers/frontend/src/routes/auth/user/$username.lazy.tsx
@@ -15,6 +15,7 @@ export const Route = createLazyFileRoute('/auth/user/$username')({
 })
 
 interface PublicProfile {
+  id?: number
   username: string
   first_name: string
   last_name: string
@@ -64,6 +65,14 @@ function PublicProfile() {
 
       const data = await response.json()
       setProfile(data)
+
+      // Registrar la visita al perfil (dedup en backend por 24h, ignorar errores).
+      if (data?.id) {
+        fetch(`${apiUrl}/api/v1/users/${data.id}/view`, {
+          method: 'POST',
+          credentials: 'include',
+        }).catch(() => { /* silent */ })
+      }
     } catch (error) {
       setError('Error al cargar el perfil')
     } finally {

--- a/containers/frontend/src/routes/auth/user/profile.lazy.tsx
+++ b/containers/frontend/src/routes/auth/user/profile.lazy.tsx
@@ -12,6 +12,7 @@ import { Loader2, Camera, MapPin, Plus, X } from 'lucide-react'
 import { LocationSelector } from '@/components/profile/LocationSelector'
 import { AddPortfolioItem } from '@/components/portfolio/AddPortfolioItem'
 import { PortfolioGallery } from '@/components/portfolio/PortfolioGallery'
+import { UsernameSettings } from '@/components/profile/UsernameSettings'
 
 export const Route = createLazyFileRoute('/auth/user/profile')({
   component: MyProfile
@@ -410,6 +411,16 @@ function MyProfile() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Username settings */}
+      <div className="mt-6">
+        <UsernameSettings
+          currentUsername={profile.username}
+          onChanged={(newUsername) =>
+            setProfile((prev) => (prev ? { ...prev, username: newUsername } : prev))
+          }
+        />
+      </div>
 
       {/* Portfolio Section */}
       <div className="mt-6">

--- a/containers/frontend/src/services/notifications/notificationsApi.tsx
+++ b/containers/frontend/src/services/notifications/notificationsApi.tsx
@@ -65,6 +65,7 @@ export const deleteNotification = async (notificationId: number): Promise<void> 
 // Obtener preferencias de notificaciones
 export const getNotificationPreferences = async (): Promise<{
   email_notifications: boolean
+  notify_profile_views: boolean
   push_notifications: boolean
 }> => {
   const response = await axios.get(`${API_URL}/api/v1/notifications/preferences`, {
@@ -76,7 +77,8 @@ export const getNotificationPreferences = async (): Promise<{
 // Actualizar preferencias de notificaciones
 export const updateNotificationPreferences = async (preferences: {
   email_notifications?: boolean
-}): Promise<{ message: string; email_notifications: boolean }> => {
+  notify_profile_views?: boolean
+}): Promise<{ message: string; email_notifications: boolean; notify_profile_views: boolean }> => {
   const response = await axios.put(`${API_URL}/api/v1/notifications/preferences`, preferences, {
     withCredentials: true,
   })


### PR DESCRIPTION
Closes Issue #5.

## Backend
- `ProfileView` model (+ migration `13_profile_views_username`) with `(viewed_id, viewed_at)` and `(viewer_id, viewed_id, viewed_at)` indexes, `no_self_profile_view` check.
- `POST /api/v1/users/<id>/view` with 24h dedup; creates in-app notification for the viewed user if `notify_profile_views` is enabled.
- New `notify_profile_views` and `username_changed_at` columns on `user`.
- `email_tasks.send_weekly_digests` now uses the real profile views count (distinct viewers in last 7 days).
- `PUT /api/v1/users/me/username` with Pydantic validation, uniqueness check and 30-day cooldown.
- `GET /api/v1/users/me/username/availability` for live feedback.
- Notification preferences API exposes `notify_profile_views`.

## Frontend
- Public profile page registers a view when loaded.
- New `UsernameSettings` component wired into the profile page with debounced availability check.
- `NotificationSettings` gains a toggle for profile-view notifications.

## Tests / verification
- Backend: python `ast.parse` passes on all touched modules.
- Frontend: `tsc --noEmit` error count unchanged vs. main (pre-existing errors only).