### PR TITLE
feat(issue-6.3): integrate Sentry for frontend observability

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -136,19 +136,11 @@ Creados los componentes reutilizables `EmptyState`, `ErrorState`, `ErrorBoundary
 
 ## Issue #6.3 — Observabilidad frontend (Sentry/alternativa)
 
-**Estado:** `pending`
+**Estado:** `done`
 **Severidad:** Baja (calidad)
+**Completado en:** `<sha>` — 2026-04-19
 
-### Tareas
-
-- [ ] Integrar `@sentry/react` con `init()` condicional a env var `VITE_SENTRY_DSN`.
-- [ ] Conectar `ErrorBoundary` (`src/components/error/ErrorBoundary.tsx`) via `onError` a `Sentry.captureException`.
-- [ ] Instrumentar `window.addEventListener('error' | 'unhandledrejection')` en `main.tsx` sin duplicar el envío.
-- [ ] Adjuntar `release` y `environment` a partir de Vite env vars.
-- [ ] Documentar en `NOTIFICATIONS_SETUP.md` (o nuevo `OBSERVABILITY.md`) cómo provisionar el DSN por entorno.
-
-### Criterio de aceptación
-- Un error lanzado manualmente en dev llega a Sentry (o se registra localmente si DSN no está seteado).
+Añadido `@sentry/react` con helper `src/lib/sentry.ts` que inicializa condicional a `VITE_SENTRY_DSN`, respetando `VITE_SENTRY_ENVIRONMENT`/`VITE_SENTRY_RELEASE` y ratios (`TRACES_SAMPLE_RATE`, `REPLAYS_*`). `initSentry()` se llama en `main.tsx` antes de los listeners globales, de modo que la integración `GlobalHandlers` de Sentry (que maneja `error` y `unhandledrejection`) se registra primero y no se duplica con los handlers de auto-reload de módulos dinámicos. `ErrorBoundary` reenvía todos los errores a `Sentry.captureException` vía el helper `captureException`, que además hace fallback a `console.error` si la integración no está activa. Nuevos tipos en `vite-env.d.ts` para las env vars y guía completa de provisioning en `OBSERVABILITY.md`.
 
 ---
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -138,7 +138,7 @@ Creados los componentes reutilizables `EmptyState`, `ErrorState`, `ErrorBoundary
 
 **Estado:** `done`
 **Severidad:** Baja (calidad)
-**Completado en:** `<sha>` — 2026-04-19
+**Completado en:** `ef5d470` — 2026-04-19
 
 Añadido `@sentry/react` con helper `src/lib/sentry.ts` que inicializa condicional a `VITE_SENTRY_DSN`, respetando `VITE_SENTRY_ENVIRONMENT`/`VITE_SENTRY_RELEASE` y ratios (`TRACES_SAMPLE_RATE`, `REPLAYS_*`). `initSentry()` se llama en `main.tsx` antes de los listeners globales, de modo que la integración `GlobalHandlers` de Sentry (que maneja `error` y `unhandledrejection`) se registra primero y no se duplica con los handlers de auto-reload de módulos dinámicos. `ErrorBoundary` reenvía todos los errores a `Sentry.captureException` vía el helper `captureException`, que además hace fallback a `console.error` si la integración no está activa. Nuevos tipos en `vite-env.d.ts` para las env vars y guía completa de provisioning en `OBSERVABILITY.md`.
 

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -1,0 +1,68 @@
+# Observabilidad frontend
+
+LocalTalent integra [Sentry](https://sentry.io/) en el frontend a través de
+`@sentry/react`. La inicialización está en
+`containers/frontend/src/lib/sentry.ts` y se arranca en `main.tsx` antes de
+registrar los handlers globales, por lo que los errores capturados por Sentry
+llegan siempre antes de cualquier `event.preventDefault()` que tengamos para el
+flujo de recarga de módulos dinámicos.
+
+`ErrorBoundary` reenvía cualquier error que captura a `Sentry.captureException`
+vía el helper `captureException` del módulo anterior. Los listeners
+`window.addEventListener('error' | 'unhandledrejection')` de `main.tsx` siguen
+existiendo sólo para la lógica de auto-reload tras un fallo de import dinámico:
+no reportan manualmente a Sentry porque la integración `GlobalHandlers` de
+`@sentry/react` ya lo hace, evitando duplicados.
+
+## Variables de entorno (Vite)
+
+Todas empiezan por `VITE_` para que queden expuestas al bundle del cliente:
+
+| Variable | Requerida | Descripción |
+| --- | --- | --- |
+| `VITE_SENTRY_DSN` | sí (para activar) | DSN del proyecto Sentry. Si está vacío, la integración queda deshabilitada y los errores sólo se loguean en consola en desarrollo. |
+| `VITE_SENTRY_ENVIRONMENT` | no | Override del entorno reportado. Por defecto usa `import.meta.env.MODE` (`development`, `production`, etc.). |
+| `VITE_SENTRY_RELEASE` | no | Identificador de release (ej: el SHA corto). Útil para filtrar issues por despliegue. |
+| `VITE_SENTRY_TRACES_SAMPLE_RATE` | no | Ratio (0–1) de traces de performance. Por defecto `0`. |
+| `VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE` | no | Ratio (0–1) de session replays. Por defecto `0`. |
+| `VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE` | no | Ratio (0–1) de replays sólo cuando hay error. Por defecto `0`. |
+
+## Provisionar por entorno
+
+1. **Local (`.env.local`)**: dejar `VITE_SENTRY_DSN` vacío para no mandar nada.
+   Cualquier `ErrorBoundary` logueará en consola en dev.
+2. **Staging / Production**: inyectar las variables en el build de Vite
+   (ej: pipeline CI o `compose.yml`). Ejemplo para Docker Compose:
+
+   ```yaml
+   frontend:
+     build:
+       args:
+         VITE_SENTRY_DSN: ${SENTRY_DSN}
+         VITE_SENTRY_ENVIRONMENT: production
+         VITE_SENTRY_RELEASE: ${GIT_SHA}
+         VITE_SENTRY_TRACES_SAMPLE_RATE: "0.1"
+   ```
+
+3. **Verificación manual**: lanzar en la consola del navegador
+   `throw new Error("sentry test")` dentro de un componente envuelto por
+   `ErrorBoundary` (por ejemplo forzando un estado de error) y comprobar que
+   aparece en el dashboard. Sin DSN, aparecerá en la consola como
+   `[sentry disabled] …`.
+
+## Extender la instrumentación
+
+Para instrumentar operaciones concretas, importa el helper:
+
+```ts
+import { captureException } from "@/lib/sentry"
+
+try {
+  await risky()
+} catch (err) {
+  captureException(err, { area: "risky" })
+}
+```
+
+Esto respeta el flag interno `initialized`: si Sentry no está configurado,
+sólo se registra en `console.error` en desarrollo.

--- a/containers/frontend/package-lock.json
+++ b/containers/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-toast": "^1.2.5",
         "@radix-ui/react-tooltip": "^1.1.7",
+        "@sentry/react": "^10.49.0",
         "@tanstack/react-router": "^1.97.0",
         "@tanstack/react-table": "^8.20.6",
         "axios": "^1.13.2",
@@ -3632,6 +3633,97 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.49.0.tgz",
+      "integrity": "sha512-n0QRx0Ysx6mPfIydTkz7VP0FmwM+/EqMZiRqdsU3aTYsngE9GmEDV0OL1bAy6a8N/C1xf9vntkuAtj6N/8Z51w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.49.0.tgz",
+      "integrity": "sha512-JNsUBGv0faCFE7MeZUH99Y9lU9qq3LBALbLxpE1x7ngNrQnVYRlcFgdqaD/btNBKr8awjYL8gmcSkHBWskGqLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.49.0.tgz",
+      "integrity": "sha512-IEy4lwHVMiRE3JAcn+kFKjsTgalDOCSTf20SoFd+nkt6rN/k1RDyr4xpdfF//Kj3UdeTmbuibYjK5H/FLhhnGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.49.0.tgz",
+      "integrity": "sha512-7D/NrgH1Qwx5trDYaaTSSJmCb1yVQQLqFG4G/S9x2ltzl9876lSGJL8UeW8ReNQgF3CDAcwbmm/9aXaVSBUNZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.49.0.tgz",
+      "integrity": "sha512-bGCHc+wK2Dx67YoSbmtlt04alqWfQ+dasD/GVipVOq50gvw/BBIDHTEWRJEjACl+LrvszeY54V+24p8z4IgysA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.49.0",
+        "@sentry-internal/feedback": "10.49.0",
+        "@sentry-internal/replay": "10.49.0",
+        "@sentry-internal/replay-canvas": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.49.0.tgz",
+      "integrity": "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.49.0.tgz",
+      "integrity": "sha512-WdfJve0orTiumr25Ozgs2p2KaJR9xV82Z5V9IYBi0TadsurSWK6xI6SAFjw84tQht9Fp8q4UCn3QYCnApF4BfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -12098,6 +12190,66 @@
       "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
       "dev": true,
       "optional": true
+    },
+    "@sentry-internal/browser-utils": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.49.0.tgz",
+      "integrity": "sha512-n0QRx0Ysx6mPfIydTkz7VP0FmwM+/EqMZiRqdsU3aTYsngE9GmEDV0OL1bAy6a8N/C1xf9vntkuAtj6N/8Z51w==",
+      "requires": {
+        "@sentry/core": "10.49.0"
+      }
+    },
+    "@sentry-internal/feedback": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.49.0.tgz",
+      "integrity": "sha512-JNsUBGv0faCFE7MeZUH99Y9lU9qq3LBALbLxpE1x7ngNrQnVYRlcFgdqaD/btNBKr8awjYL8gmcSkHBWskGqLQ==",
+      "requires": {
+        "@sentry/core": "10.49.0"
+      }
+    },
+    "@sentry-internal/replay": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.49.0.tgz",
+      "integrity": "sha512-IEy4lwHVMiRE3JAcn+kFKjsTgalDOCSTf20SoFd+nkt6rN/k1RDyr4xpdfF//Kj3UdeTmbuibYjK5H/FLhhnGg==",
+      "requires": {
+        "@sentry-internal/browser-utils": "10.49.0",
+        "@sentry/core": "10.49.0"
+      }
+    },
+    "@sentry-internal/replay-canvas": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.49.0.tgz",
+      "integrity": "sha512-7D/NrgH1Qwx5trDYaaTSSJmCb1yVQQLqFG4G/S9x2ltzl9876lSGJL8UeW8ReNQgF3CDAcwbmm/9aXaVSBUNZA==",
+      "requires": {
+        "@sentry-internal/replay": "10.49.0",
+        "@sentry/core": "10.49.0"
+      }
+    },
+    "@sentry/browser": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.49.0.tgz",
+      "integrity": "sha512-bGCHc+wK2Dx67YoSbmtlt04alqWfQ+dasD/GVipVOq50gvw/BBIDHTEWRJEjACl+LrvszeY54V+24p8z4IgysA==",
+      "requires": {
+        "@sentry-internal/browser-utils": "10.49.0",
+        "@sentry-internal/feedback": "10.49.0",
+        "@sentry-internal/replay": "10.49.0",
+        "@sentry-internal/replay-canvas": "10.49.0",
+        "@sentry/core": "10.49.0"
+      }
+    },
+    "@sentry/core": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.49.0.tgz",
+      "integrity": "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g=="
+    },
+    "@sentry/react": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.49.0.tgz",
+      "integrity": "sha512-WdfJve0orTiumr25Ozgs2p2KaJR9xV82Z5V9IYBi0TadsurSWK6xI6SAFjw84tQht9Fp8q4UCn3QYCnApF4BfA==",
+      "requires": {
+        "@sentry/browser": "10.49.0",
+        "@sentry/core": "10.49.0"
+      }
     },
     "@socket.io/component-emitter": {
       "version": "3.1.2",

--- a/containers/frontend/package.json
+++ b/containers/frontend/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.5",
     "@radix-ui/react-tooltip": "^1.1.7",
+    "@sentry/react": "^10.49.0",
     "@tanstack/react-router": "^1.97.0",
     "@tanstack/react-table": "^8.20.6",
     "axios": "^1.13.2",

--- a/containers/frontend/src/components/error/ErrorBoundary.tsx
+++ b/containers/frontend/src/components/error/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from "react"
 import { ErrorState } from "@/components/ui/error-state"
+import { captureException } from "@/lib/sentry"
 
 interface ErrorBoundaryProps {
   children: ReactNode
@@ -19,6 +20,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    captureException(error, { componentStack: info.componentStack })
     if (this.props.onError) {
       this.props.onError(error, info)
     } else if (import.meta.env.DEV) {

--- a/containers/frontend/src/lib/sentry.ts
+++ b/containers/frontend/src/lib/sentry.ts
@@ -1,0 +1,38 @@
+import * as Sentry from "@sentry/react"
+
+let initialized = false
+
+export function initSentry() {
+  if (initialized) return
+  const dsn = import.meta.env.VITE_SENTRY_DSN
+  if (!dsn) return
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE,
+    release: import.meta.env.VITE_SENTRY_RELEASE,
+    tracesSampleRate: Number(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ?? 0),
+    replaysSessionSampleRate: Number(
+      import.meta.env.VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE ?? 0,
+    ),
+    replaysOnErrorSampleRate: Number(
+      import.meta.env.VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE ?? 0,
+    ),
+  })
+
+  initialized = true
+}
+
+export function isSentryEnabled() {
+  return initialized
+}
+
+export function captureException(error: unknown, context?: Record<string, unknown>) {
+  if (!initialized) {
+    if (import.meta.env.DEV) {
+      console.error("[sentry disabled]", error, context)
+    }
+    return
+  }
+  Sentry.captureException(error, context ? { extra: context } : undefined)
+}

--- a/containers/frontend/src/main.tsx
+++ b/containers/frontend/src/main.tsx
@@ -8,6 +8,9 @@ import "./index.css";
 import "leaflet/dist/leaflet.css";
 import { Toaster } from "@/components/ui/sonner"; // Importar Toaster
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
+import { initSentry } from "@/lib/sentry";
+
+initSentry();
 
 // Manejo de errores de importación dinámica
 // Esto evita errores cuando el navegador tiene cacheada una versión antigua

--- a/containers/frontend/src/vite-env.d.ts
+++ b/containers/frontend/src/vite-env.d.ts
@@ -1,3 +1,14 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_SENTRY_DSN?: string
+  readonly VITE_SENTRY_ENVIRONMENT?: string
+  readonly VITE_SENTRY_RELEASE?: string
+  readonly VITE_SENTRY_TRACES_SAMPLE_RATE?: string
+  readonly VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE?: string
+  readonly VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE?: string
+}
 
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
Closes Issue #6.3 from ISSUES.md.

## Summary

- Adds `@sentry/react` with a conditional init driven by `VITE_SENTRY_DSN`. No DSN = no network calls and errors fall through to console in dev.
- New `src/lib/sentry.ts` helper (`initSentry`, `captureException`, `isSentryEnabled`).
- `ErrorBoundary.componentDidCatch` now forwards captured errors (with component stack) to Sentry via `captureException`.
- `initSentry()` runs in `main.tsx` before the existing dynamic-import reload listeners so Sentry's `GlobalHandlers` integration registers first and owns reporting of `error` / `unhandledrejection` — no duplicate sends.
- Types the new `VITE_SENTRY_*` env vars in `vite-env.d.ts`.
- New `OBSERVABILITY.md` documents env vars, Compose example, and manual verification.

## Test plan
- [ ] With `VITE_SENTRY_DSN` set, throwing an error inside a component under `ErrorBoundary` produces an event in Sentry.
- [ ] Without DSN, the same throw logs `[sentry disabled]` in dev and the app still shows the fallback UI.
- [ ] Existing dynamic-import auto-reload flow still triggers.