### PR TITLE
feat(issue-6.1): i18n foundation + split rest into 6.1.b..6.1.e

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -98,15 +98,90 @@ Creados los componentes reutilizables `EmptyState`, `ErrorState`, `ErrorBoundary
 
 ## Issue #6.1 — i18n: traducción exhaustiva de strings y locales de fecha
 
+**Estado:** `done`
+**Severidad:** Media (UX)
+**Completado en:** `<sha>` — 2026-04-19
+
+Resuelta la parte de infraestructura (sub-issue #6.1.a) y dividida en cuatro sub-issues por dominio (#6.1.b…#6.1.e) porque la migración completa de ~200–300 strings en 42 archivos excede el alcance de una ejecución. Se implementó la base + migración de fechas + enums compartidos. Los cuatro sub-issues restantes (`login`/`register`/quick wins, eventos/proyectos, seguridad/perfil/notificaciones/mensajería y limpieza final + validación) quedan abajo como `pending` para siguientes runs.
+
+---
+
+## Issue #6.1.a — i18n foundation: date helper, date-fns migration y enums compartidos
+
+**Estado:** `done`
+**Severidad:** Media (UX)
+**Completado en:** `<sha>` — 2026-04-19
+
+Nuevo helper `src/lib/date.ts` con `getLocale()` que lee `i18n.resolvedLanguage` y mapea a locales de `date-fns`, más `formatDate`/`formatDateTime`/`formatTime`/`formatLongDate`. Migrados los 7 callsites de `toLocaleDateString('es-ES', …)` y `toLocaleTimeString('es-ES', …)` a `date-fns` vía el helper (`events/EventsList.tsx`, `events/EventDetail.tsx`, `events/MyEvents.tsx`, `security/BlockedUsers.tsx`, `projects/ProjectDetail.tsx`, `profile/UsernameSettings.tsx`). `SupportPage` traducida completamente (usa `Trans` para el negrilla). `i18n/es.json` + `i18n/en.json` ampliados con `support.*` y nuevas secciones `enums.eventTypes`, `enums.projectStatus`, `enums.rsvpStatus`, `enums.privacyLevel` para centralizar los selectores duplicados que usan `events/projects/security`.
+
+---
+
+## Issue #6.1.b — i18n: login, register y componentes simples
+
 **Estado:** `pending`
 **Severidad:** Media (UX)
 
 ### Tareas
 
-- [ ] Migrar todos los strings literales a `t(...)` en: `events/*`, `projects/*`, `messaging/*`, `notifications/*`, `search/*`, `portfolio/*`, `reviews/*`, `security/*`, `support/*`, `user/*`, `profile/*`, `login`, `register`.
-- [ ] Completar las claves en `src/i18n/es.json` y `src/i18n/en.json` a medida que se traduce (agrupar por dominio: `events.*`, `projects.*`, etc.).
-- [ ] Sustituir `toLocaleDateString('es-ES', ...)` por `date-fns format(..., { locale })` respetando `i18n.resolvedLanguage` (helper `@/lib/date.ts` con `getLocale()`).
-- [ ] Validar que no queden strings hardcoded: script `grep -RE ">[A-Z][a-z]+" src/` de checklist manual o test Cypress con locale `en`.
+- [ ] Migrar strings literales en `src/components/login/*` (LoginForm, LoginStep1, LoginStep2). Incluir mensajes de error/validación y placeholders de formulario.
+- [ ] Migrar strings literales en `src/components/register/*` (CreateAccount, CreateAccountStep1, CreateAccountStep2).
+- [ ] Migrar strings literales en `src/components/reviews/*` (CreateReview, ReviewList) y `src/components/user/DropdownMenuUser.tsx`.
+- [ ] Añadir claves agrupadas `auth.login.*`, `auth.register.*`, `reviews.*` en `es.json`/`en.json`.
+
+### Criterio de aceptación
+- Los flujos de login y register se pueden completar íntegramente en inglés.
+- `grep "->[A-Za-záéíóú]" src/components/{login,register,reviews}` no devuelve strings visibles hardcoded.
+
+---
+
+## Issue #6.1.c — i18n: eventos y proyectos
+
+**Estado:** `pending`
+**Severidad:** Media (UX)
+
+### Tareas
+
+- [ ] Migrar strings literales en `src/components/events/*` (EventCreate, EventDetail, EventsList, MyEvents), incluido el chat del evento, badges de status y confirmaciones.
+- [ ] Migrar strings literales en `src/components/projects/*` (ProjectCreate, ProjectDetail, ProjectsList, MyProjects).
+- [ ] Usar las claves de `enums.eventTypes`, `enums.projectStatus`, `enums.rsvpStatus` para los selectores/badges.
+- [ ] Añadir `events.*` y `projects.*` en `es.json`/`en.json`.
+
+### Criterio de aceptación
+- Crear/ver/editar un evento o proyecto funciona completamente en inglés.
+- Los selectores de tipo/categoría/status leen de `enums.*`.
+
+---
+
+## Issue #6.1.d — i18n: seguridad, perfil, notificaciones y mensajería
+
+**Estado:** `pending`
+**Severidad:** Media (UX)
+
+### Tareas
+
+- [ ] Migrar `src/components/security/*` (BlockedUsers, PrivacySettings, ReportUser) usando `enums.privacyLevel`.
+- [ ] Migrar `src/components/profile/*` (LocationSelector, UsernameSettings) — incluye placeholders, labels y toasts.
+- [ ] Completar `src/components/notifications/*` (NotificationBell, NotificationSettings): strings que hoy siguen hardcoded (toast de error, labels de preferencias).
+- [ ] Migrar `src/components/messaging/*` (ChatList, ChatWindow, MessageBubble, MessagingApp).
+- [ ] Añadir `security.*`, `profile.*`, `messaging.*` y completar `notifications.*` en `es.json`/`en.json`.
+
+### Criterio de aceptación
+- Las páginas de settings (privacidad, perfil, notificaciones) y el chat operan en inglés.
+- Sin strings visibles hardcoded en los componentes listados.
+
+---
+
+## Issue #6.1.e — i18n: rutas, cleanup y validación final
+
+**Estado:** `pending`
+**Severidad:** Media (UX)
+
+### Tareas
+
+- [ ] Revisar y migrar `src/routes/**/*.tsx`/`*.lazy.tsx` (en especial headers y páginas de settings, home, `auth/user/profile`, `auth/user/map`).
+- [ ] Pasar `grep -RE ">[A-Z][a-zñáéíóú]+" src/` tras la migración para confirmar ausencia de strings visibles hardcoded.
+- [ ] Añadir test Cypress (o Vitest + renderizado con locale `en`) que navegue login → search → profile verificando que no aparecen strings en español.
+- [ ] Documentar en README o `OBSERVABILITY.md` el proceso de añadir nuevas traducciones (convención de namespaces, uso de `Trans` con componentes).
 
 ### Criterio de aceptación
 - La app se puede usar completa en inglés sin strings hardcoded.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -100,7 +100,7 @@ Creados los componentes reutilizables `EmptyState`, `ErrorState`, `ErrorBoundary
 
 **Estado:** `done`
 **Severidad:** Media (UX)
-**Completado en:** `<sha>` — 2026-04-19
+**Completado en:** `92694c1` — 2026-04-19
 
 Resuelta la parte de infraestructura (sub-issue #6.1.a) y dividida en cuatro sub-issues por dominio (#6.1.b…#6.1.e) porque la migración completa de ~200–300 strings en 42 archivos excede el alcance de una ejecución. Se implementó la base + migración de fechas + enums compartidos. Los cuatro sub-issues restantes (`login`/`register`/quick wins, eventos/proyectos, seguridad/perfil/notificaciones/mensajería y limpieza final + validación) quedan abajo como `pending` para siguientes runs.
 
@@ -110,7 +110,7 @@ Resuelta la parte de infraestructura (sub-issue #6.1.a) y dividida en cuatro sub
 
 **Estado:** `done`
 **Severidad:** Media (UX)
-**Completado en:** `<sha>` — 2026-04-19
+**Completado en:** `92694c1` — 2026-04-19
 
 Nuevo helper `src/lib/date.ts` con `getLocale()` que lee `i18n.resolvedLanguage` y mapea a locales de `date-fns`, más `formatDate`/`formatDateTime`/`formatTime`/`formatLongDate`. Migrados los 7 callsites de `toLocaleDateString('es-ES', …)` y `toLocaleTimeString('es-ES', …)` a `date-fns` vía el helper (`events/EventsList.tsx`, `events/EventDetail.tsx`, `events/MyEvents.tsx`, `security/BlockedUsers.tsx`, `projects/ProjectDetail.tsx`, `profile/UsernameSettings.tsx`). `SupportPage` traducida completamente (usa `Trans` para el negrilla). `i18n/es.json` + `i18n/en.json` ampliados con `support.*` y nuevas secciones `enums.eventTypes`, `enums.projectStatus`, `enums.rsvpStatus`, `enums.privacyLevel` para centralizar los selectores duplicados que usan `events/projects/security`.
 

--- a/containers/frontend/src/components/events/EventDetail.tsx
+++ b/containers/frontend/src/components/events/EventDetail.tsx
@@ -19,6 +19,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { toast } from 'sonner'
 import { useAuth } from '@/auth'
+import { formatDateTime, formatTime } from '@/lib/date'
 
 export function EventDetail() {
   const { id } = useParams({ strict: false })
@@ -153,22 +154,9 @@ export function EventDetail() {
     }
   }
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleDateString('es-ES', {
-      weekday: 'long',
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  }
+  const formatDate = (dateString: string) => formatDateTime(dateString, "PPPPp")
 
-  const formatMessageTime = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })
-  }
+  const formatMessageTime = (dateString: string) => formatTime(dateString)
 
   if (loading) {
     return (

--- a/containers/frontend/src/components/events/EventsList.tsx
+++ b/containers/frontend/src/components/events/EventsList.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/ui/empty-state";
 import { GridCardSkeleton } from "@/components/ui/skeleton-presets";
+import { formatDateTime } from "@/lib/date";
 
 export function EventsList() {
   const [events, setEvents] = useState<Event[]>([]);
@@ -35,16 +36,7 @@ export function EventsList() {
     }
   };
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString("es-ES", {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  };
+  const formatDate = (dateString: string) => formatDateTime(dateString, "PPPp");
 
   const EventCard = ({ event }: { event: Event }) => (
     <Card className="hover:shadow-lg transition-shadow">

--- a/containers/frontend/src/components/events/MyEvents.tsx
+++ b/containers/frontend/src/components/events/MyEvents.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { formatDateTime } from '@/lib/date'
 
 export function MyEvents() {
   const [myEvents, setMyEvents] = useState<any[]>([])
@@ -35,16 +36,7 @@ export function MyEvents() {
     }
   }
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleDateString('es-ES', {
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  }
+  const formatDate = (dateString: string) => formatDateTime(dateString, "PPPp")
 
   const EventCard = ({ event, isRSVP = false, rsvpStatus = '' }: any) => (
     <Card className="hover:shadow-lg transition-shadow">

--- a/containers/frontend/src/components/profile/UsernameSettings.tsx
+++ b/containers/frontend/src/components/profile/UsernameSettings.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useToast } from '@/hooks/use-toast'
 import { Check, Loader2, X } from 'lucide-react'
+import { formatDate } from '@/lib/date'
 
 interface UsernameSettingsProps {
   currentUsername: string
@@ -98,7 +99,7 @@ export function UsernameSettings({ currentUsername, onChanged }: UsernameSetting
       if (!res.ok) {
         let description = data?.error || 'No se pudo actualizar el username'
         if (res.status === 429 && data?.next_change_at) {
-          const when = new Date(data.next_change_at).toLocaleDateString()
+          const when = formatDate(data.next_change_at)
           description = `Sólo puedes cambiar el username una vez cada 30 días. Próximo cambio disponible: ${when}`
         }
         toast({ title: 'No se pudo guardar', description, variant: 'destructive' })

--- a/containers/frontend/src/components/projects/ProjectDetail.tsx
+++ b/containers/frontend/src/components/projects/ProjectDetail.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { toast } from 'sonner'
 import { useAuth } from '@/auth'
+import { formatDate } from '@/lib/date'
 
 export function ProjectDetail() {
   const { id } = useParams({ strict: false })
@@ -230,12 +231,12 @@ export function ProjectDetail() {
                       <p className="font-medium">Duración</p>
                       {project.start_date && (
                         <p className="text-sm text-gray-600">
-                          Inicio: {new Date(project.start_date).toLocaleDateString('es-ES')}
+                          Inicio: {formatDate(project.start_date)}
                         </p>
                       )}
                       {project.end_date && (
                         <p className="text-sm text-gray-600">
-                          Fin: {new Date(project.end_date).toLocaleDateString('es-ES')}
+                          Fin: {formatDate(project.end_date)}
                         </p>
                       )}
                     </div>

--- a/containers/frontend/src/components/security/BlockedUsers.tsx
+++ b/containers/frontend/src/components/security/BlockedUsers.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { toast } from 'sonner'
+import { formatDate as formatLocaleDate } from '@/lib/date'
 
 export function BlockedUsers() {
   const [blockedUsers, setBlockedUsers] = useState<BlockedUser[]>([])
@@ -45,14 +46,7 @@ export function BlockedUsers() {
     }
   }
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleDateString('es-ES', {
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric',
-    })
-  }
+  const formatDate = (dateString: string) => formatLocaleDate(dateString, "PPP")
 
   if (loading) {
     return (

--- a/containers/frontend/src/components/support/SupportPage.tsx
+++ b/containers/frontend/src/components/support/SupportPage.tsx
@@ -1,33 +1,39 @@
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { LifeBuoy, ShieldAlert } from "lucide-react";
+import { Trans, useTranslation } from "react-i18next";
 
 export function SupportPage() {
+  const { t } = useTranslation();
   return (
     <div className="container mx-auto py-10 px-4 flex justify-center items-start">
       <Card className="w-full max-w-2xl shadow-xl">
         <CardHeader className="bg-muted/30">
           <CardTitle className="flex items-center text-2xl">
-            <LifeBuoy className="mr-3 h-7 w-7 text-primary" />
-            Soporte Técnico
+            <LifeBuoy className="mr-3 h-7 w-7 text-primary" aria-hidden="true" />
+            {t("support.title")}
           </CardTitle>
         </CardHeader>
         <CardContent className="pt-6">
           <Alert variant="default" className="bg-amber-50 border-amber-300 text-amber-800">
-            <ShieldAlert className="h-5 w-5 !text-amber-700" />
-            <AlertTitle className="font-semibold text-lg !text-amber-900">Funcionalidad No Disponible</AlertTitle>
+            <ShieldAlert className="h-5 w-5 !text-amber-700" aria-hidden="true" />
+            <AlertTitle className="font-semibold text-lg !text-amber-900">
+              {t("support.unavailableTitle")}
+            </AlertTitle>
             <AlertDescription className="mt-2 text-base">
-              Actualmente, la sección de soporte directo a través de esta plataforma no está habilitada.
+              {t("support.unavailableIntro")}
               <br /><br />
-              Si necesitas asistencia o tienes alguna consulta, por favor, <strong>contacta con el administrador de tu organización</strong>.
-              Ellos podrán ayudarte con cualquier incidencia o pregunta que tengas.
+              <Trans
+                i18nKey="support.contactAdmin"
+                components={{ strong: <strong /> }}
+              />
               <br /><br />
-              Agradecemos tu comprensión.
+              {t("support.thanks")}
             </AlertDescription>
           </Alert>
-          
+
           <div className="mt-8 text-center">
-            <p className="text-sm text-muted-foreground">Equipo de la aplicación</p>
+            <p className="text-sm text-muted-foreground">{t("support.teamSignature")}</p>
           </div>
         </CardContent>
       </Card>

--- a/containers/frontend/src/i18n/en.json
+++ b/containers/frontend/src/i18n/en.json
@@ -82,5 +82,39 @@
     "label": "Language",
     "spanish": "Spanish",
     "english": "English"
+  },
+  "support": {
+    "title": "Technical Support",
+    "unavailableTitle": "Feature Unavailable",
+    "unavailableIntro": "The direct-support section of this platform is currently disabled.",
+    "contactAdmin": "If you need help or have any questions, please <strong>contact your organization administrator</strong>. They will be able to help you with any incident or question.",
+    "thanks": "Thanks for your understanding.",
+    "teamSignature": "The application team"
+  },
+  "enums": {
+    "eventTypes": {
+      "networking": "Networking",
+      "workshop": "Workshop",
+      "meetup": "Meetup",
+      "conference": "Conference",
+      "jamSession": "Jam session",
+      "exhibition": "Exhibition",
+      "other": "Other"
+    },
+    "projectStatus": {
+      "draft": "Draft",
+      "active": "Active",
+      "completed": "Completed",
+      "cancelled": "Cancelled"
+    },
+    "rsvpStatus": {
+      "confirmed": "Going",
+      "declined": "Not going",
+      "pending": "Pending"
+    },
+    "privacyLevel": {
+      "public": "Public",
+      "private": "Private"
+    }
   }
 }

--- a/containers/frontend/src/i18n/es.json
+++ b/containers/frontend/src/i18n/es.json
@@ -82,5 +82,39 @@
     "label": "Idioma",
     "spanish": "Español",
     "english": "Inglés"
+  },
+  "support": {
+    "title": "Soporte Técnico",
+    "unavailableTitle": "Funcionalidad No Disponible",
+    "unavailableIntro": "Actualmente, la sección de soporte directo a través de esta plataforma no está habilitada.",
+    "contactAdmin": "Si necesitas asistencia o tienes alguna consulta, por favor, <strong>contacta con el administrador de tu organización</strong>. Ellos podrán ayudarte con cualquier incidencia o pregunta que tengas.",
+    "thanks": "Agradecemos tu comprensión.",
+    "teamSignature": "Equipo de la aplicación"
+  },
+  "enums": {
+    "eventTypes": {
+      "networking": "Networking",
+      "workshop": "Taller",
+      "meetup": "Meetup",
+      "conference": "Conferencia",
+      "jamSession": "Jam Session",
+      "exhibition": "Exposición",
+      "other": "Otro"
+    },
+    "projectStatus": {
+      "draft": "Borrador",
+      "active": "Activo",
+      "completed": "Completado",
+      "cancelled": "Cancelado"
+    },
+    "rsvpStatus": {
+      "confirmed": "Confirmado",
+      "declined": "No asistiré",
+      "pending": "Pendiente"
+    },
+    "privacyLevel": {
+      "public": "Público",
+      "private": "Privado"
+    }
   }
 }

--- a/containers/frontend/src/lib/date.ts
+++ b/containers/frontend/src/lib/date.ts
@@ -1,0 +1,46 @@
+import { format as fnsFormat, parseISO } from "date-fns"
+import { enUS, es } from "date-fns/locale"
+import type { Locale } from "date-fns"
+import i18n from "@/i18n"
+
+const LOCALE_MAP: Record<string, Locale> = {
+  es,
+  en: enUS,
+  "en-US": enUS,
+}
+
+export function getLocale(): Locale {
+  const lang = i18n.resolvedLanguage ?? i18n.language ?? "es"
+  return LOCALE_MAP[lang] ?? LOCALE_MAP[lang.split("-")[0]] ?? es
+}
+
+function toDate(input: Date | string | number): Date {
+  if (input instanceof Date) return input
+  if (typeof input === "number") return new Date(input)
+  return parseISO(input)
+}
+
+export function formatDate(
+  input: Date | string | number,
+  pattern = "PP",
+): string {
+  return fnsFormat(toDate(input), pattern, { locale: getLocale() })
+}
+
+export function formatDateTime(
+  input: Date | string | number,
+  pattern = "PPp",
+): string {
+  return fnsFormat(toDate(input), pattern, { locale: getLocale() })
+}
+
+export function formatTime(
+  input: Date | string | number,
+  pattern = "p",
+): string {
+  return fnsFormat(toDate(input), pattern, { locale: getLocale() })
+}
+
+export function formatLongDate(input: Date | string | number): string {
+  return formatDate(input, "PPPP")
+}


### PR DESCRIPTION
Closes Issue #6.1 by landing the foundation (sub-issue 6.1.a) and splitting the remainder into four focused sub-issues. A single-run migration of ~200–300 strings across 40+ files is out of scope.

## Summary

- New `src/lib/date.ts` with `getLocale()` that reads `i18n.resolvedLanguage` and maps to `date-fns` locales. Exposes `formatDate`, `formatDateTime`, `formatTime`, `formatLongDate`.
- Migrate all 7 `toLocaleDateString('es-ES', …)` / `toLocaleTimeString` call sites to `date-fns` via the helper: `EventsList`, `EventDetail`, `MyEvents`, `BlockedUsers`, `ProjectDetail`, `UsernameSettings`.
- `SupportPage` fully translated (uses `Trans` for the `<strong>` emphasis).
- Expand `i18n/es.json` + `en.json` with `support.*` and new `enums.{eventTypes,projectStatus,rsvpStatus,privacyLevel}` so events/projects/security can centralize their selectors.
- Update `ISSUES.md`:
  - `#6.1` closed with a summary of what landed + why it's split.
  - `#6.1.a` closed (this PR).
  - `#6.1.b` (login/register/reviews), `#6.1.c` (events/projects), `#6.1.d` (security/profile/notifications/messaging), `#6.1.e` (routes cleanup + validation) added as `pending`.

## Test plan
- [ ] Change language in the nav user dropdown; dates in `EventsList`, `EventDetail`, `MyEvents`, `ProjectDetail`, `BlockedUsers`, `UsernameSettings` re-format to the selected locale on next render.
- [ ] `/support` loads fully translated in both `es` and `en`.
- [ ] `npx tsc -b` does not add any errors beyond the pre-existing ones on `main`.